### PR TITLE
chore(actions): Add git plugin to semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx -p @semantic-release/changelog -p semantic-release semantic-release
+        run: npx -p @semantic-release/changelog -p @semantic-release/git -p semantic-release semantic-release
 

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -2,4 +2,5 @@ plugins:
 - "@semantic-release/commit-analyzer"
 - "@semantic-release/release-notes-generator"
 - "@semantic-release/changelog"
+- "@semantic-release/git"
 - "@semantic-release/github"


### PR DESCRIPTION
This should allow changelogs to be published back to GitHub

Signed-off-by: Lucian <lucian.buzzo@gmail.com>