### PR TITLE
feat(cli): port verify chain and ledger summary

### DIFF
--- a/MIGRATION_TODO.md
+++ b/MIGRATION_TODO.md
@@ -78,7 +78,7 @@ Subcommands (empty or stubbed initially):
 ## Phase 3 — Port Deterministic Ledger Operations (Low Risk)
 
 ### 3.1 Chain verification
-- [ ] Port `scripts/verify_chain.js` → Crystal `verify:chain`
+- [x] Port `scripts/verify_chain.js` → Crystal `verify:chain`
 
 ### 3.2 Apply block
 - [ ] Port `scripts/apply_block.js` → Crystal `ledger:apply-block`
@@ -87,7 +87,7 @@ Subcommands (empty or stubbed initially):
 - [ ] Port `scripts/mint_rewards.js` → Crystal `rewards:mint`
 
 ### 3.4 Summary/reporting
-- [ ] Port `scripts/ledger_summary.js` → Crystal `ledger:summary`
+- [x] Port `scripts/ledger_summary.js` → Crystal `ledger:summary`
 
 **Acceptance:** parity tests pass against existing fixture data.
 

--- a/spec/cli_spec.cr
+++ b/spec/cli_spec.cr
@@ -1,0 +1,116 @@
+require "digest/sha256"
+require "file_utils"
+require "json"
+require "spec"
+require "../src/sequin/cli"
+
+private def with_temp_ledger
+  root = File.join(Dir.tempdir, "sequin-cli-spec-#{Random.rand(1_000_000)}")
+  begin
+    FileUtils.mkdir_p(File.join(root, "ledger", "blocks"))
+    FileUtils.mkdir_p(File.join(root, "ledger", "state"))
+    yield root
+  ensure
+    FileUtils.rm_rf(root)
+  end
+end
+
+private def write_json(path : String, contents : String)
+  File.write(path, contents)
+end
+
+private def write_chain_fixture(root : String)
+  blocks_dir = File.join(root, "ledger", "blocks")
+  state_dir = File.join(root, "ledger", "state")
+
+  genesis_path = File.join(blocks_dir, "000000.json")
+  genesis = %({"height":0,"prevHash":null})
+  write_json(genesis_path, genesis)
+
+  genesis_hash = Digest::SHA256.hexdigest(File.read(genesis_path).to_slice)
+  block_one_path = File.join(blocks_dir, "000001.json")
+  block_one = %({"height":1,"prevHash":"#{genesis_hash}"})
+  write_json(block_one_path, block_one)
+
+  write_json(File.join(state_dir, "meta.json"), %({"chain":"sequin-github","version":1,"lastHeight":1,"lastUpdated":"2026-03-14T12:00:00Z"}))
+  write_json(File.join(state_dir, "balances.json"), %({"zoe":7,"alice":12,"bob":12.5}))
+  write_json(File.join(state_dir, "reward_epochs.json"), %(["2026-03-12","2026-03-13","2026-03-14"]))
+end
+
+describe Sequin::Commands::VerifyChain do
+  it "matches the JS success output for a valid chain" do
+    with_temp_ledger do |root|
+      write_chain_fixture(root)
+      stdout = IO::Memory.new
+      stderr = IO::Memory.new
+
+      exit_code = Sequin::Commands::VerifyChain.new(stdout, stderr).call(root)
+
+      exit_code.should eq(0)
+      stdout.to_s.should eq("✅ Chain valid (2 blocks, tip=1)\n")
+      stderr.to_s.should eq("")
+    end
+  end
+
+  it "fails when block linkage is invalid" do
+    with_temp_ledger do |root|
+      write_chain_fixture(root)
+      block_one_path = File.join(root, "ledger", "blocks", "000001.json")
+      write_json(block_one_path, %({"height":1,"prevHash":"bogus"}))
+
+      stdout = IO::Memory.new
+      stderr = IO::Memory.new
+
+      exit_code = Sequin::Commands::VerifyChain.new(stdout, stderr).call(root)
+
+      exit_code.should eq(1)
+      stdout.to_s.should eq("")
+      stderr.to_s.should contain("❌ 000001.json: prevHash mismatch")
+    end
+  end
+end
+
+describe Sequin::Commands::LedgerSummary do
+  it "prints the same summary structure as the JS script" do
+    with_temp_ledger do |root|
+      write_chain_fixture(root)
+      stdout = IO::Memory.new
+
+      exit_code = Sequin::Commands::LedgerSummary.new(stdout).call(
+        Sequin::Commands::LedgerSummary::Options.new(top: 2, epochs: 2),
+        root
+      )
+
+      exit_code.should eq(0)
+      stdout.to_s.should eq <<-TEXT
+Chain: sequin-github v1 | tip=1
+Last updated: 2026-03-14T12:00:00Z
+
+Top 2 balances:
+- bob: 12.5
+- alice: 12
+
+Recent minted reward epochs (2/3):
+- 2026-03-14
+- 2026-03-13
+
+TEXT
+    end
+  end
+end
+
+describe Sequin::CLI do
+  it "routes verify:chain through the CLI entrypoint" do
+    with_temp_ledger do |root|
+      write_chain_fixture(root)
+      stdout = IO::Memory.new
+      stderr = IO::Memory.new
+
+      exit_code = Sequin::CLI.new(stdout, stderr).run(["verify:chain"], root)
+
+      exit_code.should eq(0)
+      stdout.to_s.should eq("✅ Chain valid (2 blocks, tip=1)\n")
+      stderr.to_s.should eq("")
+    end
+  end
+end

--- a/src/sequin/cli.cr
+++ b/src/sequin/cli.cr
@@ -1,0 +1,78 @@
+require "./commands/ledger_summary"
+require "./commands/verify_chain"
+
+module Sequin
+  class CLI
+    USAGE = <<-TEXT
+    Usage:
+      sequin verify:chain
+      sequin ledger:summary [--top N] [--epochs N]
+    TEXT
+
+    def initialize(@stdout : IO = STDOUT, @stderr : IO = STDERR)
+    end
+
+    def run(args : Array(String), root : String = Dir.current) : Int32
+      command = args[0]?
+      return usage(1) unless command
+
+      case command
+      when "verify:chain"
+        Commands::VerifyChain.new(@stdout, @stderr).call(root)
+      when "ledger:summary"
+        options = parse_ledger_summary_options(args[1..], @stderr)
+        return 1 unless options
+        Commands::LedgerSummary.new(@stdout).call(options, root)
+      else
+        @stderr.puts "Unknown command: #{command}"
+        usage(1)
+      end
+    end
+
+    private def usage(code : Int32) : Int32
+      @stderr.puts USAGE
+      code
+    end
+
+    private def parse_ledger_summary_options(args : Array(String), stderr : IO) : Commands::LedgerSummary::Options?
+      top = 10
+      epochs = 5
+      index = 0
+
+      while index < args.size
+        flag = args[index]
+        value = args[index + 1]?
+
+        case flag
+        when "--top"
+          return option_error("#{flag} requires a value", stderr) unless value
+          parsed = parse_int(flag, value, stderr)
+          return nil unless parsed
+          top = parsed
+          index += 2
+        when "--epochs"
+          return option_error("#{flag} requires a value", stderr) unless value
+          parsed = parse_int(flag, value, stderr)
+          return nil unless parsed
+          epochs = parsed
+          index += 2
+        else
+          return option_error("Unknown option: #{flag}", stderr)
+        end
+      end
+
+      Commands::LedgerSummary::Options.new(top: top, epochs: epochs)
+    end
+
+    private def parse_int(flag : String, value : String, stderr : IO) : Int32?
+      parsed = value.to_i?
+      return parsed if parsed
+      option_error("#{flag} must be an integer, found #{value}", stderr)
+    end
+
+    private def option_error(message : String, stderr : IO)
+      stderr.puts message
+      nil
+    end
+  end
+end

--- a/src/sequin/commands/ledger_summary.cr
+++ b/src/sequin/commands/ledger_summary.cr
@@ -1,0 +1,79 @@
+require "json"
+
+module Sequin
+  module Commands
+    class LedgerSummary
+      record Options, top : Int32 = 10, epochs : Int32 = 5
+
+      def initialize(@stdout : IO = STDOUT)
+      end
+
+      def call(options : Options = Options.new, root : String = Dir.current) : Int32
+        balances = read_json(File.join(root, "ledger", "state", "balances.json"), "{}").as_h
+        meta = read_json(File.join(root, "ledger", "state", "meta.json"), "{}").as_h
+        minted = read_json(File.join(root, "ledger", "state", "reward_epochs.json"), "[]").as_a
+
+        top = balances
+          .to_a
+          .sort do |left, right|
+            amount_comparison = numeric_value(right[1]) <=> numeric_value(left[1])
+            next amount_comparison unless amount_comparison == 0
+            left[0] <=> right[0]
+          end
+          .first(options.top)
+
+        chain = string_or(meta["chain"]?, "unknown")
+        version = printable_or(meta["version"]?, "?")
+        tip = printable_or(meta["lastHeight"]?, "?")
+        last_updated = string_or(meta["lastUpdated"]?, "n/a")
+
+        @stdout.puts "Chain: #{chain} v#{version} | tip=#{tip}"
+        @stdout.puts "Last updated: #{last_updated}"
+        @stdout.puts
+        @stdout.puts "Top #{top.size} balances:"
+        top.each do |user, amount|
+          @stdout.puts "- #{user}: #{amount.raw}"
+        end
+
+        @stdout.puts
+        @stdout.puts "Recent minted reward epochs (#{Math.min(options.epochs, minted.size)}/#{minted.size}):"
+
+        minted.last(options.epochs).reverse_each do |epoch|
+          @stdout.puts "- #{epoch.as_s}"
+        end
+
+        0
+      end
+
+      private def read_json(path : String, fallback : String) : JSON::Any
+        return JSON.parse(fallback) unless File.exists?(path)
+        JSON.parse(File.read(path))
+      end
+
+      private def numeric_value(value : JSON::Any) : Float64
+        raw = value.raw
+        case raw
+        when Int64
+          raw.to_f
+        when Float64
+          raw
+        else
+          0.0
+        end
+      end
+
+      private def printable_or(value : JSON::Any?, fallback : String) : String
+        return fallback unless value
+        raw = value.raw
+        return fallback if raw.nil?
+        raw.to_s
+      end
+
+      private def string_or(value : JSON::Any?, fallback : String) : String
+        return fallback unless value
+        raw = value.raw
+        raw.is_a?(String) ? raw : fallback
+      end
+    end
+  end
+end

--- a/src/sequin/commands/verify_chain.cr
+++ b/src/sequin/commands/verify_chain.cr
@@ -1,0 +1,66 @@
+require "digest/sha256"
+require "json"
+
+module Sequin
+  module Commands
+    class VerifyChain
+      def initialize(@stdout : IO = STDOUT, @stderr : IO = STDERR)
+      end
+
+      def call(root : String = Dir.current) : Int32
+        blocks_dir = File.join(root, "ledger", "blocks")
+        meta_path = File.join(root, "ledger", "state", "meta.json")
+
+        return fail("Missing ledger/blocks directory") unless Dir.exists?(blocks_dir)
+
+        files = Dir.children(blocks_dir).select(&.ends_with?(".json")).sort
+        return fail("No block files found") if files.empty?
+
+        prev_hash = nil.as(String?)
+        expected_height = 0_i64
+
+        files.each do |file|
+          path = File.join(blocks_dir, file)
+          block = JSON.parse(File.read(path)).as_h
+          height = block["height"].as_i64
+          prev_hash_value = block["prevHash"]?.try(&.raw).as(String?)
+
+          if height != expected_height
+            return fail("#{file}: expected height #{expected_height}, found #{height}")
+          end
+
+          if prev_hash_value != prev_hash
+            return fail("#{file}: prevHash mismatch, expected #{printable(prev_hash)}, found #{printable(prev_hash_value)}")
+          end
+
+          prev_hash = Digest::SHA256.hexdigest(File.read(path).to_slice)
+          expected_height += 1
+        end
+
+        tip_height = expected_height - 1
+        meta = JSON.parse(File.read(meta_path)).as_h
+        last_height = meta["lastHeight"].as_i64
+
+        if last_height != tip_height
+          return fail("meta.lastHeight mismatch: expected #{tip_height}, found #{last_height}")
+        end
+
+        @stdout.puts "✅ Chain valid (#{files.size} blocks, tip=#{tip_height})"
+        0
+      rescue ex : File::NotFoundError
+        fail(ex.message || ex.class.name)
+      rescue ex : JSON::ParseException
+        fail(ex.message || ex.class.name)
+      end
+
+      private def fail(message : String) : Int32
+        @stderr.puts "❌ #{message}"
+        1
+      end
+
+      private def printable(value : String?) : String
+        value || "null"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- port `verify_chain` and `ledger_summary` behavior from JS scripts into Crystal commands
- wire commands into Crystal CLI path
- add specs for command behavior and output semantics

## Notes
- JS scripts are intentionally retained for now during migration

## Testing
- added CLI command specs for verify/summary
