### PR TITLE
chore: add make target for native repo validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: \
 	all\
 	lint\
-	test
+	test\
+	validate-native
 
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
@@ -15,3 +16,8 @@ lint:
 
 test:
 	crystal spec
+
+# Runs fast, GitHub-native validation checks for repo data + scripts
+validate-native:
+	node scripts/lint_repo.js
+	node scripts/verify_chain.js

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ node scripts/sequin_cli.js tx:sign --from <you> --to <them> --amount 10 --nonce 
 ### Validation scripts
 
 ```bash
+make validate-native
 node scripts/verify_chain.js
 node scripts/verify_tx.js
 node scripts/score_epoch.js --date YYYY-MM-DD


### PR DESCRIPTION
## Summary
- add a `make validate-native` target for quick, GitHub-native repository checks
- wire the target to run `scripts/lint_repo.js` and `scripts/verify_chain.js`
- document the new shortcut in README validation commands

## Why
The repo has shifted toward GitHub-native ledger tooling, but local validation currently requires remembering individual node scripts. This target gives a fast, deterministic preflight command with minimal blast radius.

## Testing
- `make validate-native`
  - ✅ JSON files checked: 9
  - ✅ JS files syntax-checked: 8
  - ✅ Chain valid (1 blocks, tip=0)
