### PR TITLE
ci: switch unit workflow runner to ubuntu-latest

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit:
     name: Run unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- switch unit workflow runner from `ubuntu-20.04` to `ubuntu-latest`
- unblock CI jobs that are currently stuck queued on unavailable 20.04 runners

## Why
Recent CI jobs across master/PRs are queued indefinitely with `labels: ["ubuntu-20.04"]` and no assigned runner.

## Testing
- workflow-only change; validate by observing new CI run scheduling/execution
