### PR TITLE
feat(cli): port apply-block and rewards-mint commands

### DIFF
--- a/MIGRATION_TODO.md
+++ b/MIGRATION_TODO.md
@@ -32,14 +32,14 @@
 ## Phase 1 — Crystal Toolchain Upgrade
 
 ### 1.1 Runtime/tooling modernization
-- [ ] Upgrade Crystal version from `0.35.1` to current stable target
-- [ ] Update `shard.yml` and dependency constraints
-- [ ] Verify `shards install` + test suite locally
+- [x] Upgrade Crystal version from `0.35.1` to current stable target
+- [x] Update `shard.yml` and dependency constraints
+- [x] Verify `shards install` + test suite locally
 
 **Acceptance:** CI `unit` green on upgrade PR.
 
 ### 1.2 Dependency hygiene
-- [ ] Mark `kemal` + `crest` as legacy (temporary)
+- [x] Mark `kemal` + `crest` as legacy (temporary)
 - [ ] Add required deps for:
   - [ ] crypto path
   - [ ] HTTP/GitHub API client robustness
@@ -53,23 +53,23 @@
 
 Create `sequin_tool` (single entrypoint, subcommands).
 
-- [ ] Add command router and shared helpers:
-  - [ ] JSON read/write
-  - [ ] canonical serialization
-  - [ ] fs safety helpers
-  - [ ] structured error output
+- [x] Add command router and shared helpers:
+  - [x] JSON read/write
+  - [x] canonical serialization
+  - [x] fs safety helpers
+  - [x] structured error output
 
 Subcommands (empty or stubbed initially):
-- [ ] `verify:chain`
-- [ ] `verify:tx`
-- [ ] `ledger:apply-block`
-- [ ] `rewards:score-epoch`
-- [ ] `rewards:mint`
-- [ ] `ledger:summary`
-- [ ] `wallet:create`
-- [ ] `tx:next-nonce`
-- [ ] `tx:sign`
-- [ ] `repo:lint`
+- [x] `verify:chain`
+- [x] `verify:tx`
+- [x] `ledger:apply-block`
+- [x] `rewards:score-epoch`
+- [x] `rewards:mint`
+- [x] `ledger:summary`
+- [x] `wallet:create`
+- [x] `tx:next-nonce`
+- [x] `tx:sign`
+- [x] `repo:lint`
 
 **Acceptance:** binary runs and each command returns a clear status.
 
@@ -81,10 +81,10 @@ Subcommands (empty or stubbed initially):
 - [x] Port `scripts/verify_chain.js` → Crystal `verify:chain`
 
 ### 3.2 Apply block
-- [ ] Port `scripts/apply_block.js` → Crystal `ledger:apply-block`
+- [x] Port `scripts/apply_block.js` → Crystal `ledger:apply-block`
 
 ### 3.3 Mint rewards
-- [ ] Port `scripts/mint_rewards.js` → Crystal `rewards:mint`
+- [x] Port `scripts/mint_rewards.js` → Crystal `rewards:mint`
 
 ### 3.4 Summary/reporting
 - [x] Port `scripts/ledger_summary.js` → Crystal `ledger:summary`
@@ -151,8 +151,8 @@ Subcommands (empty or stubbed initially):
 ## Phase 7 — Remove Legacy Paths
 
 ### 7.1 Remove server/miner model
-- [ ] Delete legacy server entrypoints and peer/mining runtime
-- [ ] Remove related deps/config/docs
+- [x] Delete legacy server entrypoints and peer/mining runtime
+- [x] Remove related deps/config/docs
 
 ### 7.2 Remove JS scaffolding
 - [ ] Delete migrated JS scripts
@@ -181,9 +181,9 @@ Run end-to-end in dry run and real flow:
 
 ## PR Plan (Recommended)
 
-- [ ] PR-1: Toolchain upgrade + AGENTS/MIGRATION docs
-- [ ] PR-2: `sequin_tool` skeleton + shared libs
-- [ ] PR-3: deterministic ledger ops port
+- [x] PR-1: Toolchain upgrade + AGENTS/MIGRATION docs
+- [x] PR-2: `sequin_tool` skeleton + shared libs
+- [x] PR-3: deterministic ledger ops port
 - [ ] PR-4: epoch scoring port + hardening
 - [ ] PR-5: crypto + tx tooling port
 - [ ] PR-6: workflow cutover

--- a/spec/sequin_tool_spec.cr
+++ b/spec/sequin_tool_spec.cr
@@ -1,5 +1,17 @@
+require "file_utils"
 require "spec"
+require "json"
 require "../src/sequin_tool/cli"
+
+private def with_tmp_repo
+  dir = File.join(Dir.tempdir, "sequin-spec-#{Random::Secure.hex(6)}")
+  begin
+    Dir.mkdir_p(dir)
+    yield dir
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end
 
 describe SequinTool::CLI do
   it "prints top-level help" do
@@ -8,31 +20,143 @@ describe SequinTool::CLI do
     stderr = IO::Memory.new
 
     cli.run(["--help"], stdout, stderr).should eq(0)
-    stdout.to_s.should contain("sequin_tool - unified Crystal CLI skeleton")
+    stdout.to_s.should contain("sequin_tool - unified Crystal CLI")
     stdout.to_s.should contain("verify:chain")
     stderr.to_s.should eq("")
   end
 
-  it "prints command help" do
-    cli = SequinTool::CLI.new
-    stdout = IO::Memory.new
-    stderr = IO::Memory.new
+  it "runs verify:chain successfully against minimal ledger" do
+    with_tmp_repo do |root|
+      Dir.mkdir_p(File.join(root, "ledger", "blocks"))
+      Dir.mkdir_p(File.join(root, "ledger", "state"))
 
-    cli.run(["help", "wallet:create"], stdout, stderr).should eq(0)
-    stdout.to_s.should contain("wallet:create - Create a wallet keypair")
-    stdout.to_s.should contain("Implementation target: Phase 5")
-    stderr.to_s.should eq("")
+      File.write(File.join(root, "ledger", "blocks", "000000.json"), {
+        "height" => 0,
+        "prevHash" => nil,
+        "txIds" => [] of String,
+        "timestamp" => "2026-03-13T00:00:00Z",
+        "proposer" => "genesis",
+      }.to_pretty_json + "\n")
+
+      File.write(File.join(root, "ledger", "state", "meta.json"), {
+        "chain" => "sequin-github",
+        "version" => 1,
+        "lastHeight" => 0,
+        "lastUpdated" => nil,
+      }.to_pretty_json + "\n")
+
+      cli = SequinTool::CLI.new
+      stdout = IO::Memory.new
+      stderr = IO::Memory.new
+
+      cli.run(["verify:chain"], stdout, stderr, root).should eq(0)
+      stdout.to_s.should contain("Chain valid")
+      stderr.to_s.should eq("")
+    end
   end
 
-  it "returns a clear stub response for a routed command" do
-    cli = SequinTool::CLI.new
-    stdout = IO::Memory.new
-    stderr = IO::Memory.new
+  it "applies a pending tx into a new block" do
+    with_tmp_repo do |root|
+      Dir.mkdir_p(File.join(root, "ledger", "blocks"))
+      Dir.mkdir_p(File.join(root, "ledger", "state"))
+      Dir.mkdir_p(File.join(root, "tx", "pending"))
 
-    cli.run(["verify:chain"], stdout, stderr).should eq(1)
-    stdout.to_s.should eq("")
-    stderr.to_s.should contain(%("status":"stub"))
-    stderr.to_s.should contain(%("command":"verify:chain"))
+      File.write(File.join(root, "ledger", "blocks", "000000.json"), {
+        "height" => 0,
+        "prevHash" => nil,
+        "txIds" => [] of String,
+        "timestamp" => "2026-03-13T00:00:00Z",
+        "proposer" => "genesis",
+      }.to_pretty_json + "\n")
+      File.write(File.join(root, "ledger", "state", "meta.json"), {
+        "chain" => "sequin-github",
+        "version" => 1,
+        "lastHeight" => 0,
+        "lastUpdated" => nil,
+      }.to_pretty_json + "\n")
+      File.write(File.join(root, "ledger", "state", "balances.json"), {"alice" => 100, "bob" => 0}.to_pretty_json + "\n")
+      File.write(File.join(root, "ledger", "state", "nonces.json"), {"alice" => 0}.to_pretty_json + "\n")
+
+      tx = {
+        "id" => "tx-1",
+        "from" => "alice",
+        "to" => "bob",
+        "amount" => 15,
+        "nonce" => 1,
+        "sigVersion" => 1,
+        "memo" => "",
+        "createdAt" => "2026-03-14T00:00:00Z",
+        "signature" => "stub",
+      }
+      File.write(File.join(root, "tx", "pending", "2026-03-14T00-00-00Z__tx-1.json"), tx.to_pretty_json + "\n")
+
+      cli = SequinTool::CLI.new
+      stdout = IO::Memory.new
+      stderr = IO::Memory.new
+
+      cli.run(["ledger:apply-block"], stdout, stderr, root).should eq(0)
+      stdout.to_s.should contain("Applied block #1")
+      stderr.to_s.should eq("")
+
+      balances = JSON.parse(File.read(File.join(root, "ledger", "state", "balances.json"))).as_h
+      balances["alice"].as_i.should eq(85)
+      balances["bob"].as_i.should eq(15)
+      Dir.children(File.join(root, "tx", "pending")).should be_empty
+    end
+  end
+
+  it "mints rewards for an epoch" do
+    with_tmp_repo do |root|
+      Dir.mkdir_p(File.join(root, "ledger", "blocks"))
+      Dir.mkdir_p(File.join(root, "ledger", "state"))
+      Dir.mkdir_p(File.join(root, "rewards"))
+      Dir.mkdir_p(File.join(root, "config"))
+
+      File.write(File.join(root, "ledger", "blocks", "000000.json"), {
+        "height" => 0,
+        "prevHash" => nil,
+        "txIds" => [] of String,
+        "timestamp" => "2026-03-13T00:00:00Z",
+        "proposer" => "genesis",
+      }.to_pretty_json + "\n")
+      File.write(File.join(root, "ledger", "state", "meta.json"), {
+        "chain" => "sequin-github",
+        "version" => 1,
+        "lastHeight" => 0,
+        "lastUpdated" => nil,
+      }.to_pretty_json + "\n")
+      File.write(File.join(root, "ledger", "state", "balances.json"), ({} of String => Int32).to_pretty_json + "\n")
+      File.write(File.join(root, "ledger", "state", "reward_epochs.json"), ([] of String).to_pretty_json + "\n")
+      File.write(File.join(root, "config", "reward-repos.json"), {
+        "dailyEmission" => 10000,
+        "maxRewardPerUser" => 3000,
+      }.to_pretty_json + "\n")
+
+      reward = {
+        "epoch" => "2026-03-13",
+        "totals" => {"dailyEmission" => 10000},
+        "rewards" => [
+          {"github" => "alice", "amount" => 2000},
+          {"github" => "bob", "amount" => 1000},
+        ],
+      }
+      File.write(File.join(root, "rewards", "2026-03-13.json"), reward.to_pretty_json + "\n")
+
+      cli = SequinTool::CLI.new
+      stdout = IO::Memory.new
+      stderr = IO::Memory.new
+
+      cli.run(["rewards:mint", "--date", "2026-03-13"], stdout, stderr, root).should eq(0)
+      stdout.to_s.should contain("Minted reward epoch 2026-03-13")
+      stderr.to_s.should eq("")
+
+      balances = JSON.parse(File.read(File.join(root, "ledger", "state", "balances.json"))).as_h
+      balances["alice"].as_i.should eq(2000)
+      balances["bob"].as_i.should eq(1000)
+
+      epochs = JSON.parse(File.read(File.join(root, "ledger", "state", "reward_epochs.json"))).as_a
+      epochs.map(&.as_s).should contain("2026-03-13")
+    end
   end
 
   it "returns a structured error for unknown commands" do

--- a/src/sequin_tool/cli.cr
+++ b/src/sequin_tool/cli.cr
@@ -1,4 +1,9 @@
+require "option_parser"
 require "./command"
+require "./commands/apply_block"
+require "./commands/ledger_summary"
+require "./commands/mint_rewards"
+require "./commands/verify_chain"
 require "./error_handling"
 require "./fs"
 require "./json_io"
@@ -9,12 +14,8 @@ module SequinTool
 
     def initialize
       @commands = [
-        Command.new("verify:chain", "Verify canonical ledger chain state.", "Command stub only. Chain verification will be ported in Phase 3.", "Phase 3", exit_code: 1),
         Command.new("verify:tx", "Verify a pending transaction payload.", "Command stub only. Transaction verification will be ported in Phase 5.", "Phase 5", exit_code: 1),
-        Command.new("ledger:apply-block", "Apply pending transactions into ledger state.", "Command stub only. Block application will be ported in Phase 3.", "Phase 3", exit_code: 1),
         Command.new("rewards:score-epoch", "Score GitHub activity for a reward epoch.", "Command stub only. Epoch scoring will be ported in Phase 4.", "Phase 4", exit_code: 1),
-        Command.new("rewards:mint", "Mint a reward manifest into ledger state.", "Command stub only. Reward minting will be ported in Phase 3.", "Phase 3", exit_code: 1),
-        Command.new("ledger:summary", "Print a ledger summary report.", "Command stub only. Ledger reporting will be ported in Phase 3.", "Phase 3", exit_code: 1),
         Command.new("wallet:create", "Create a wallet keypair and public registration payload.", "Command stub only. Wallet creation will be ported in Phase 5.", "Phase 5", exit_code: 1),
         Command.new("tx:next-nonce", "Compute the next nonce for a wallet.", "Command stub only. Nonce lookup will be ported in Phase 5.", "Phase 5", exit_code: 1),
         Command.new("tx:sign", "Sign a transfer payload.", "Command stub only. Transaction signing will be ported in Phase 5.", "Phase 5", exit_code: 1),
@@ -22,7 +23,7 @@ module SequinTool
       ]
     end
 
-    def run(args : Array(String), stdout : IO = STDOUT, stderr : IO = STDERR) : Int32
+    def run(args : Array(String), stdout : IO = STDOUT, stderr : IO = STDERR, root : String = Dir.current) : Int32
       if args.empty? || help_flag?(args[0])
         write_help(stdout)
         return 0
@@ -32,16 +33,31 @@ module SequinTool
         return help_for(args[1]?, stdout, stderr)
       end
 
-      command = commands.find { |item| item.name == args[0] }
-      unless command
-        raise CLIError.new(
-          "Unknown command",
-          exit_code: 2,
-          details: {"command" => args[0]}
-        )
-      end
+      case args[0]
+      when "verify:chain"
+        Commands::VerifyChain.new(stdout, stderr).call(root)
+      when "ledger:summary"
+        options = parse_ledger_summary_options(args[1..], stderr)
+        return 1 unless options
+        Commands::LedgerSummary.new(stdout).call(options, root)
+      when "ledger:apply-block"
+        Commands::ApplyBlock.new(stdout, stderr).call(root)
+      when "rewards:mint"
+        date = parse_date_option(args[1..], stderr)
+        return 1 if date == :error
+        Commands::MintRewards.new(stdout, stderr).call(date.as(String?), root)
+      else
+        command = commands.find { |item| item.name == args[0] }
+        unless command
+          raise CLIError.new(
+            "Unknown command",
+            exit_code: 2,
+            details: {"command" => args[0]}
+          )
+        end
 
-      command.call(args[1..], stdout, stderr)
+        command.call(args[1..], stdout, stderr)
+      end
     rescue ex : CLIError
       ErrorHandling.handle(stderr, ex)
     rescue ex
@@ -49,20 +65,22 @@ module SequinTool
     end
 
     def write_help(io : IO)
-      io.puts "sequin_tool - unified Crystal CLI skeleton for GitHub-backed Sequin"
+      io.puts "sequin_tool - unified Crystal CLI for GitHub-backed Sequin"
       io.puts
       io.puts "Usage:"
       io.puts "  sequin_tool <command> [options]"
       io.puts "  sequin_tool help <command>"
       io.puts
-      io.puts "Available commands:"
-
+      io.puts "Implemented commands:"
+      io.puts "  verify:chain          Verify canonical ledger chain state."
+      io.puts "  ledger:summary        Print a ledger summary report."
+      io.puts "  ledger:apply-block    Apply pending transactions into ledger state."
+      io.puts "  rewards:mint          Mint a reward manifest into ledger state."
+      io.puts
+      io.puts "Stub commands:"
       commands.each do |command|
         io.puts "  #{command.name.ljust(20)} #{command.summary}"
       end
-
-      io.puts
-      io.puts "Each command is currently a Crystal scaffold stub. Use '<command> --help' for status details."
     end
 
     private def help_flag?(arg : String) : Bool
@@ -75,6 +93,27 @@ module SequinTool
         return 0
       end
 
+      case name
+      when "verify:chain"
+        stdout.puts "verify:chain - Verify canonical ledger chain state."
+        stdout.puts
+        stdout.puts "Validates block heights, prevHash linkage, and meta.lastHeight."
+        return 0
+      when "ledger:summary"
+        stdout.puts "ledger:summary - Print ledger summary."
+        stdout.puts
+        stdout.puts "Options: --top N --epochs N"
+        return 0
+      when "ledger:apply-block"
+        stdout.puts "ledger:apply-block - Apply pending tx files into a new block."
+        return 0
+      when "rewards:mint"
+        stdout.puts "rewards:mint - Mint reward manifest into ledger state."
+        stdout.puts
+        stdout.puts "Options: --date YYYY-MM-DD"
+        return 0
+      end
+
       command = commands.find { |item| item.name == name }
       unless command
         raise CLIError.new("Unknown command", exit_code: 2, details: {"command" => name})
@@ -82,6 +121,60 @@ module SequinTool
 
       command.help(stdout)
       0
+    end
+
+    private def parse_ledger_summary_options(args : Array(String), stderr : IO) : Commands::LedgerSummary::Options?
+      top = 10
+      epochs = 5
+      index = 0
+
+      while index < args.size
+        flag = args[index]
+        value = args[index + 1]?
+
+        case flag
+        when "--top"
+          return option_error("#{flag} requires a value", stderr) unless value
+          parsed = parse_int(flag, value, stderr)
+          return nil unless parsed
+          top = parsed
+          index += 2
+        when "--epochs"
+          return option_error("#{flag} requires a value", stderr) unless value
+          parsed = parse_int(flag, value, stderr)
+          return nil unless parsed
+          epochs = parsed
+          index += 2
+        else
+          return option_error("Unknown option: #{flag}", stderr)
+        end
+      end
+
+      Commands::LedgerSummary::Options.new(top: top, epochs: epochs)
+    end
+
+    private def parse_date_option(args : Array(String), stderr : IO) : String | Symbol | Nil
+      return nil if args.empty?
+      return :error if args.size != 2 || args[0] != "--date"
+
+      date = args[1]
+      unless /^\d{4}-\d{2}-\d{2}$/.matches?(date)
+        stderr.puts "--date must be YYYY-MM-DD"
+        return :error
+      end
+
+      date
+    end
+
+    private def parse_int(flag : String, value : String, stderr : IO) : Int32?
+      parsed = value.to_i?
+      return parsed if parsed
+      option_error("#{flag} must be an integer, found #{value}", stderr)
+    end
+
+    private def option_error(message : String, stderr : IO)
+      stderr.puts message
+      nil
     end
   end
 end

--- a/src/sequin_tool/commands/apply_block.cr
+++ b/src/sequin_tool/commands/apply_block.cr
@@ -1,0 +1,109 @@
+require "digest/sha256"
+require "json"
+
+module SequinTool
+  module Commands
+    class ApplyBlock
+      def initialize(@stdout : IO = STDOUT, @stderr : IO = STDERR)
+      end
+
+      def call(root : String = Dir.current) : Int32
+        blocks_dir = File.join(root, "ledger", "blocks")
+        balances_path = File.join(root, "ledger", "state", "balances.json")
+        nonces_path = File.join(root, "ledger", "state", "nonces.json")
+        meta_path = File.join(root, "ledger", "state", "meta.json")
+        pending_dir = File.join(root, "tx", "pending")
+
+        Dir.mkdir_p(blocks_dir)
+
+        pending_files = Dir.exists?(pending_dir) ? Dir.children(pending_dir).select(&.ends_with?(".json")).sort : [] of String
+
+        if pending_files.empty?
+          @stdout.puts "No pending tx files; nothing to apply."
+          return 0
+        end
+
+        balances = read_hash_any(balances_path)
+        nonces = read_hash_any(nonces_path)
+        meta = read_hash_any(meta_path)
+
+        txs = pending_files.map { |file| {file: file, data: JSON.parse(File.read(File.join(pending_dir, file))).as_h} }
+
+        txs.each do |tx|
+          data = tx[:data]
+          from = data["from"].as_s
+          to = data["to"].as_s
+          amount = as_int(data["amount"])
+          nonce = as_int(data["nonce"])
+
+          from_balance = hash_int(balances, from)
+          raise CLIError.new("Insufficient balance for #{from}", exit_code: 1) if from_balance < amount
+
+          expected_nonce = hash_int(nonces, from) + 1
+          if nonce != expected_nonce
+            raise CLIError.new("Bad nonce for #{from}: expected #{expected_nonce}, got #{nonce}", exit_code: 1)
+          end
+
+          balances[from] = JSON::Any.new(from_balance - amount)
+          balances[to] = JSON::Any.new(hash_int(balances, to) + amount)
+          nonces[from] = JSON::Any.new(nonce)
+        end
+
+        last_height = hash_int(meta, "lastHeight")
+        next_height = last_height + 1
+
+        prev_block_path = File.join(blocks_dir, "#{last_height.to_s.rjust(6, '0')}.json")
+        prev_hash = File.exists?(prev_block_path) ? Digest::SHA256.hexdigest(File.read(prev_block_path).to_slice) : nil
+
+        block = {
+          "height"    => JSON::Any.new(next_height),
+          "prevHash"  => prev_hash ? JSON::Any.new(prev_hash) : JSON::Any.new(nil),
+          "txIds"     => JSON::Any.new(txs.map { |t| JSON::Any.new(t[:data]["id"].as_s) }),
+          "timestamp" => JSON::Any.new(Time.utc.to_rfc3339),
+          "proposer"  => JSON::Any.new("github-actions[bot]"),
+        }
+
+        block_path = File.join(blocks_dir, "#{next_height.to_s.rjust(6, '0')}.json")
+        write_json(block_path, JSON::Any.new(block))
+        write_json(balances_path, JSON::Any.new(balances))
+        write_json(nonces_path, JSON::Any.new(nonces))
+
+        meta["lastHeight"] = JSON::Any.new(next_height)
+        meta["lastUpdated"] = JSON::Any.new(Time.utc.to_rfc3339)
+        write_json(meta_path, JSON::Any.new(meta))
+
+        pending_files.each { |file| File.delete(File.join(pending_dir, file)) }
+
+        @stdout.puts "Applied block ##{next_height} with #{txs.size} tx(s)"
+        0
+      end
+
+      private def read_hash_any(path : String) : Hash(String, JSON::Any)
+        return {} of String => JSON::Any unless File.exists?(path)
+        JSON.parse(File.read(path)).as_h
+      end
+
+      private def as_int(value : JSON::Any) : Int64
+        raw = value.raw
+        case raw
+        when Int64
+          raw
+        when Float64
+          raw.to_i64
+        else
+          raise CLIError.new("Expected integer numeric value", exit_code: 1)
+        end
+      end
+
+      private def hash_int(hash : Hash(String, JSON::Any), key : String) : Int64
+        value = hash[key]?
+        return 0_i64 unless value
+        as_int(value)
+      end
+
+      private def write_json(path : String, any : JSON::Any)
+        File.write(path, any.to_pretty_json + "\n")
+      end
+    end
+  end
+end

--- a/src/sequin_tool/commands/ledger_summary.cr
+++ b/src/sequin_tool/commands/ledger_summary.cr
@@ -1,0 +1,79 @@
+require "json"
+
+module SequinTool
+  module Commands
+    class LedgerSummary
+      record Options, top : Int32 = 10, epochs : Int32 = 5
+
+      def initialize(@stdout : IO = STDOUT)
+      end
+
+      def call(options : Options = Options.new, root : String = Dir.current) : Int32
+        balances = read_json(File.join(root, "ledger", "state", "balances.json"), "{}").as_h
+        meta = read_json(File.join(root, "ledger", "state", "meta.json"), "{}").as_h
+        minted = read_json(File.join(root, "ledger", "state", "reward_epochs.json"), "[]").as_a
+
+        top = balances
+          .to_a
+          .sort do |left, right|
+            amount_comparison = numeric_value(right[1]) <=> numeric_value(left[1])
+            next amount_comparison unless amount_comparison == 0
+            left[0] <=> right[0]
+          end
+          .first(options.top)
+
+        chain = string_or(meta["chain"]?, "unknown")
+        version = printable_or(meta["version"]?, "?")
+        tip = printable_or(meta["lastHeight"]?, "?")
+        last_updated = string_or(meta["lastUpdated"]?, "n/a")
+
+        @stdout.puts "Chain: #{chain} v#{version} | tip=#{tip}"
+        @stdout.puts "Last updated: #{last_updated}"
+        @stdout.puts
+        @stdout.puts "Top #{top.size} balances:"
+        top.each do |user, amount|
+          @stdout.puts "- #{user}: #{amount.raw}"
+        end
+
+        @stdout.puts
+        @stdout.puts "Recent minted reward epochs (#{Math.min(options.epochs, minted.size)}/#{minted.size}):"
+
+        minted.last(options.epochs).reverse_each do |epoch|
+          @stdout.puts "- #{epoch.as_s}"
+        end
+
+        0
+      end
+
+      private def read_json(path : String, fallback : String) : JSON::Any
+        return JSON.parse(fallback) unless File.exists?(path)
+        JSON.parse(File.read(path))
+      end
+
+      private def numeric_value(value : JSON::Any) : Float64
+        raw = value.raw
+        case raw
+        when Int64
+          raw.to_f
+        when Float64
+          raw
+        else
+          0.0
+        end
+      end
+
+      private def printable_or(value : JSON::Any?, fallback : String) : String
+        return fallback unless value
+        raw = value.raw
+        return fallback if raw.nil?
+        raw.to_s
+      end
+
+      private def string_or(value : JSON::Any?, fallback : String) : String
+        return fallback unless value
+        raw = value.raw
+        raw.is_a?(String) ? raw : fallback
+      end
+    end
+  end
+end

--- a/src/sequin_tool/commands/mint_rewards.cr
+++ b/src/sequin_tool/commands/mint_rewards.cr
@@ -1,0 +1,139 @@
+require "digest/sha256"
+require "json"
+
+module SequinTool
+  module Commands
+    class MintRewards
+      def initialize(@stdout : IO = STDOUT, @stderr : IO = STDERR)
+      end
+
+      def call(date : String? = nil, root : String = Dir.current) : Int32
+        epoch_date = date || (Time.utc - 1.day).to_s("%Y-%m-%d")
+
+        reward_path = File.join(root, "rewards", "#{epoch_date}.json")
+        raise CLIError.new("Missing reward manifest: #{reward_path}", exit_code: 1) unless File.exists?(reward_path)
+
+        cfg_path = File.join(root, "config", "reward-repos.json")
+        cfg = File.exists?(cfg_path) ? JSON.parse(File.read(cfg_path)).as_h : ({} of String => JSON::Any)
+
+        reward = JSON.parse(File.read(reward_path)).as_h
+        rewards = reward["rewards"]?.try(&.as_a) || raise CLIError.new("Reward manifest missing rewards array", exit_code: 1)
+        totals = reward["totals"]?.try(&.as_h) || raise CLIError.new("Reward manifest missing totals", exit_code: 1)
+
+        balances_path = File.join(root, "ledger", "state", "balances.json")
+        meta_path = File.join(root, "ledger", "state", "meta.json")
+        applied_path = File.join(root, "ledger", "state", "reward_epochs.json")
+        blocks_dir = File.join(root, "ledger", "blocks")
+
+        balances = File.exists?(balances_path) ? JSON.parse(File.read(balances_path)).as_h : ({} of String => JSON::Any)
+        meta = if File.exists?(meta_path)
+                 JSON.parse(File.read(meta_path)).as_h
+               else
+                 {
+                   "chain"       => JSON::Any.new("sequin-github"),
+                   "version"     => JSON::Any.new(1_i64),
+                   "lastHeight"  => JSON::Any.new(0_i64),
+                   "lastUpdated" => JSON::Any.new(nil),
+                 }
+               end
+        applied = File.exists?(applied_path) ? JSON.parse(File.read(applied_path)).as_a : ([] of JSON::Any)
+
+        if applied.any? { |entry| entry.as_s == epoch_date }
+          @stdout.puts "Reward epoch #{epoch_date} already minted; nothing to do."
+          return 0
+        end
+
+        distributed = rewards.sum { |row| amount_for(row) }
+        expected_emission = int_from_any(totals["dailyEmission"]?) || int_from_any(cfg["dailyEmission"]?)
+        if expected_emission && distributed > expected_emission
+          raise CLIError.new("Distributed rewards #{distributed} exceed emission cap #{expected_emission}", exit_code: 1)
+        end
+
+        max_reward_per_user = int_from_any(cfg["maxRewardPerUser"]?)
+        if max_reward_per_user
+          rewards.each do |row|
+            amount = amount_for(row)
+            github = github_for(row)
+            if amount > max_reward_per_user
+              raise CLIError.new("Reward #{amount} for #{github} exceeds per-user cap #{max_reward_per_user}", exit_code: 1)
+            end
+          end
+        end
+
+        rewards.each do |row|
+          amount = amount_for(row)
+          github = github_for(row)
+          raise CLIError.new("Invalid reward row", exit_code: 1) if amount < 0
+          next if amount == 0
+
+          balances[github] = JSON::Any.new(hash_int(balances, github) + amount)
+        end
+
+        last_height = hash_int(meta, "lastHeight")
+        next_height = last_height + 1
+
+        prev_block_path = File.join(blocks_dir, "#{last_height.to_s.rjust(6, '0')}.json")
+        prev_hash = File.exists?(prev_block_path) ? Digest::SHA256.hexdigest(File.read(prev_block_path).to_slice) : nil
+
+        tx_ids = rewards.compact_map do |row|
+          amount = amount_for(row)
+          next nil if amount <= 0
+          JSON::Any.new("reward:#{epoch_date}:#{github_for(row)}")
+        end
+
+        block = {
+          "height"    => JSON::Any.new(next_height),
+          "prevHash"  => prev_hash ? JSON::Any.new(prev_hash) : JSON::Any.new(nil),
+          "txIds"     => JSON::Any.new(tx_ids),
+          "timestamp" => JSON::Any.new(Time.utc.to_rfc3339),
+          "proposer"  => JSON::Any.new("github-actions[bot]"),
+        }
+
+        Dir.mkdir_p(blocks_dir)
+        block_path = File.join(blocks_dir, "#{next_height.to_s.rjust(6, '0')}.json")
+
+        write_json(block_path, JSON::Any.new(block))
+        write_json(balances_path, JSON::Any.new(balances))
+
+        meta["lastHeight"] = JSON::Any.new(next_height)
+        meta["lastUpdated"] = JSON::Any.new(Time.utc.to_rfc3339)
+        write_json(meta_path, JSON::Any.new(meta))
+
+        applied << JSON::Any.new(epoch_date)
+        write_json(applied_path, JSON::Any.new(applied))
+
+        @stdout.puts "✅ Minted reward epoch #{epoch_date} in block ##{next_height}"
+        0
+      end
+
+      private def write_json(path : String, any : JSON::Any)
+        File.write(path, any.to_pretty_json + "\n")
+      end
+
+      private def int_from_any(value : JSON::Any?) : Int64?
+        return nil unless value
+        raw = value.raw
+        case raw
+        when Int64
+          raw
+        when Float64
+          raw.to_i64
+        else
+          nil
+        end
+      end
+
+      private def hash_int(hash : Hash(String, JSON::Any), key : String) : Int64
+        int_from_any(hash[key]?) || 0_i64
+      end
+
+      private def github_for(row : JSON::Any) : String
+        row.as_h["github"].as_s
+      end
+
+      private def amount_for(row : JSON::Any) : Int64
+        int_from_any(row.as_h["amount"]?) || 0_i64
+      end
+    end
+  end
+end

--- a/src/sequin_tool/commands/verify_chain.cr
+++ b/src/sequin_tool/commands/verify_chain.cr
@@ -1,0 +1,66 @@
+require "digest/sha256"
+require "json"
+
+module SequinTool
+  module Commands
+    class VerifyChain
+      def initialize(@stdout : IO = STDOUT, @stderr : IO = STDERR)
+      end
+
+      def call(root : String = Dir.current) : Int32
+        blocks_dir = File.join(root, "ledger", "blocks")
+        meta_path = File.join(root, "ledger", "state", "meta.json")
+
+        return fail("Missing ledger/blocks directory") unless Dir.exists?(blocks_dir)
+
+        files = Dir.children(blocks_dir).select(&.ends_with?(".json")).sort
+        return fail("No block files found") if files.empty?
+
+        prev_hash = nil.as(String?)
+        expected_height = 0_i64
+
+        files.each do |file|
+          path = File.join(blocks_dir, file)
+          block = JSON.parse(File.read(path)).as_h
+          height = block["height"].as_i64
+          prev_hash_value = block["prevHash"]?.try(&.raw).as(String?)
+
+          if height != expected_height
+            return fail("#{file}: expected height #{expected_height}, found #{height}")
+          end
+
+          if prev_hash_value != prev_hash
+            return fail("#{file}: prevHash mismatch, expected #{printable(prev_hash)}, found #{printable(prev_hash_value)}")
+          end
+
+          prev_hash = Digest::SHA256.hexdigest(File.read(path).to_slice)
+          expected_height += 1
+        end
+
+        tip_height = expected_height - 1
+        meta = JSON.parse(File.read(meta_path)).as_h
+        last_height = meta["lastHeight"].as_i64
+
+        if last_height != tip_height
+          return fail("meta.lastHeight mismatch: expected #{tip_height}, found #{last_height}")
+        end
+
+        @stdout.puts "✅ Chain valid (#{files.size} blocks, tip=#{tip_height})"
+        0
+      rescue ex : File::NotFoundError
+        fail(ex.message || ex.class.name)
+      rescue ex : JSON::ParseException
+        fail(ex.message || ex.class.name)
+      end
+
+      private def fail(message : String) : Int32
+        @stderr.puts "❌ #{message}"
+        1
+      end
+
+      private def printable(value : String?) : String
+        value || "null"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Crystal implementations in `sequin_tool` for:
  - `verify:chain`
  - `ledger:summary`
  - `ledger:apply-block` (ported from `scripts/apply_block.js`)
  - `rewards:mint` (ported from `scripts/mint_rewards.js`)
- wire `sequin_tool` CLI to dispatch these implemented commands while leaving remaining phase commands as stubs
- add integration-style specs covering verify-chain, apply-block, and rewards-mint flows
- update `MIGRATION_TODO.md` checkboxes to reflect completed merged work and this phase-3 completion

## Testing
- `shards install`
- `crystal spec`
