### PR TITLE
refactor(workflows): run ledger and rewards flows via crystal CLI

### DIFF
--- a/.github/workflows/nightly-rewards.yml
+++ b/.github/workflows/nightly-rewards.yml
@@ -18,31 +18,40 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install system deps for Crystal linking
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libyaml-dev libevent-dev libpcre3-dev
+      - uses: MeilCli/setup-crystal-action@v4
+        with:
+          crystal_version: 1.13.2
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Install Crystal dependencies
+        run: shards install
       - name: Generate reward manifest from merged PR activity
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_DATE: ${{ github.event.inputs.date }}
         run: |
           if [ -n "${INPUT_DATE}" ]; then
-            node scripts/score_epoch.js --date "${INPUT_DATE}"
+            crystal run src/sequin_tool.cr -- rewards:score-epoch --date "${INPUT_DATE}"
           else
-            node scripts/score_epoch.js
+            crystal run src/sequin_tool.cr -- rewards:score-epoch
           fi
       - name: Mint rewards into ledger
         env:
           INPUT_DATE: ${{ github.event.inputs.date }}
         run: |
           if [ -n "${INPUT_DATE}" ]; then
-            node scripts/mint_rewards.js --date "${INPUT_DATE}"
+            crystal run src/sequin_tool.cr -- rewards:mint --date "${INPUT_DATE}"
           else
-            node scripts/mint_rewards.js
+            crystal run src/sequin_tool.cr -- rewards:mint
           fi
       - name: Verify chain + tx state
         run: |
-          node scripts/verify_chain.js
+          crystal run src/sequin_tool.cr -- verify:chain
           node scripts/verify_tx.js
       - name: Commit nightly reward/mint updates
         run: |

--- a/.github/workflows/rebuild-ledger.yml
+++ b/.github/workflows/rebuild-ledger.yml
@@ -13,15 +13,24 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install system deps for Crystal linking
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libyaml-dev libevent-dev libpcre3-dev
+      - uses: MeilCli/setup-crystal-action@v4
+        with:
+          crystal_version: 1.13.2
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Install Crystal dependencies
+        run: shards install
       - name: Verify chain structure
-        run: node scripts/verify_chain.js
+        run: crystal run src/sequin_tool.cr -- verify:chain
       - name: Verify pending tx
         run: node scripts/verify_tx.js
       - name: Apply new block from pending tx
-        run: node scripts/apply_block.js
+        run: crystal run src/sequin_tool.cr -- ledger:apply-block
       - name: Commit ledger updates (if any)
         run: |
           git config user.name "github-actions[bot]"

--- a/MIGRATION_TODO.md
+++ b/MIGRATION_TODO.md
@@ -136,10 +136,10 @@ Subcommands (empty or stubbed initially):
 - [ ] Replace Node steps with Crystal command invocations in `validate-tx.yml`
 
 ### 6.2 Rebuild ledger workflow
-- [ ] Replace Node steps with Crystal command invocations in `rebuild-ledger.yml`
+- [x] Replace Node steps with Crystal command invocations in `rebuild-ledger.yml` *(except pending tx verification, still Node until `verify:tx` is ported)*
 
 ### 6.3 Nightly rewards workflow
-- [ ] Replace Node steps with Crystal command invocations in `nightly-rewards.yml`
+- [x] Replace Node steps with Crystal command invocations in `nightly-rewards.yml` *(except tx verification, still Node until `verify:tx` is ported)*
 
 ### 6.4 CI ergonomics
 - [ ] Add build/cache strategy for Crystal binary to keep workflow duration sane


### PR DESCRIPTION
## Summary
- switch `rebuild-ledger.yml` from Node scripts to Crystal `sequin_tool` for:
  - `verify:chain`
  - `ledger:apply-block`
- switch `nightly-rewards.yml` from Node scripts to Crystal `sequin_tool` for:
  - `rewards:score-epoch`
  - `rewards:mint`
  - `verify:chain`
- keep `verify_tx.js` in both workflows as a temporary bridge until `verify:tx` is ported to Crystal
- update `MIGRATION_TODO.md` with partial Phase 6 progress notes

## Testing
- `shards install`
- `crystal spec`
