### PR TITLE
refactor(workflows): bridge validate flow to crystal and add shards cache

### DIFF
--- a/.github/workflows/nightly-rewards.yml
+++ b/.github/workflows/nightly-rewards.yml
@@ -28,6 +28,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Cache Crystal shards
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib
+            ~/.cache/shards
+          key: shards-${{ runner.os }}-${{ hashFiles('shard.lock', 'shard.yml') }}
+          restore-keys: |
+            shards-${{ runner.os }}-
       - name: Install Crystal dependencies
         run: shards install
       - name: Generate reward manifest from merged PR activity

--- a/.github/workflows/rebuild-ledger.yml
+++ b/.github/workflows/rebuild-ledger.yml
@@ -23,6 +23,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Cache Crystal shards
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib
+            ~/.cache/shards
+          key: shards-${{ runner.os }}-${{ hashFiles('shard.lock', 'shard.yml') }}
+          restore-keys: |
+            shards-${{ runner.os }}-
       - name: Install Crystal dependencies
         run: shards install
       - name: Verify chain structure

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,6 +23,16 @@ jobs:
         with:
           crystal_version: 1.13.2
 
+      - name: Cache Crystal shards
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib
+            ~/.cache/shards
+          key: shards-${{ runner.os }}-${{ hashFiles('shard.lock', 'shard.yml') }}
+          restore-keys: |
+            shards-${{ runner.os }}-
+
       - name: Run unit tests
         env:
           BALENA_DEVICE_UUID: test

--- a/.github/workflows/validate-tx.yml
+++ b/.github/workflows/validate-tx.yml
@@ -14,10 +14,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install system deps for Crystal linking
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libyaml-dev libevent-dev libpcre3-dev
+      - uses: MeilCli/setup-crystal-action@v4
+        with:
+          crystal_version: 1.13.2
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Cache Crystal shards
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib
+            ~/.cache/shards
+          key: shards-${{ runner.os }}-${{ hashFiles('shard.lock', 'shard.yml') }}
+          restore-keys: |
+            shards-${{ runner.os }}-
+      - name: Install Crystal dependencies
+        run: shards install
       - name: Validate chain structure
-        run: node scripts/verify_chain.js
+        run: crystal run src/sequin_tool.cr -- verify:chain
       - name: Validate pending tx and wallets
         run: node scripts/verify_tx.js

--- a/MIGRATION_TODO.md
+++ b/MIGRATION_TODO.md
@@ -133,7 +133,7 @@ Subcommands (empty or stubbed initially):
 ## Phase 6 — Workflow Cutover (Node → Crystal)
 
 ### 6.1 Validate tx workflow
-- [ ] Replace Node steps with Crystal command invocations in `validate-tx.yml`
+- [x] Replace Node steps with Crystal command invocations in `validate-tx.yml` *(except pending tx verification, still Node until `verify:tx` is ported)*
 
 ### 6.2 Rebuild ledger workflow
 - [x] Replace Node steps with Crystal command invocations in `rebuild-ledger.yml` *(except pending tx verification, still Node until `verify:tx` is ported)*
@@ -142,7 +142,7 @@ Subcommands (empty or stubbed initially):
 - [x] Replace Node steps with Crystal command invocations in `nightly-rewards.yml` *(except tx verification, still Node until `verify:tx` is ported)*
 
 ### 6.4 CI ergonomics
-- [ ] Add build/cache strategy for Crystal binary to keep workflow duration sane
+- [x] Add build/cache strategy for Crystal binary to keep workflow duration sane *(shards cache enabled; binary build caching can be layered later)*
 
 **Acceptance:** all three workflows green without `setup-node`.
 


### PR DESCRIPTION
## Summary
- switch validate workflow chain check to Crystal (`sequin_tool verify:chain`)
- keep pending tx verification on Node (`scripts/verify_tx.js`) as a temporary bridge until `verify:tx` is ported
- add shared shards cache (`actions/cache`) across Crystal-based workflows:
  - unit
  - validate-tx
  - rebuild-ledger
  - nightly-rewards
- update `MIGRATION_TODO.md` to mark validate-flow cutover and CI caching progress

## Testing
- `shards install`
- `crystal spec`
