### PR TITLE
feat(cli): port verify-tx and remove node from core workflows

### DIFF
--- a/.github/workflows/nightly-rewards.yml
+++ b/.github/workflows/nightly-rewards.yml
@@ -25,9 +25,6 @@ jobs:
       - uses: MeilCli/setup-crystal-action@v4
         with:
           crystal_version: 1.13.2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
       - name: Cache Crystal shards
         uses: actions/cache@v4
         with:
@@ -61,7 +58,7 @@ jobs:
       - name: Verify chain + tx state
         run: |
           crystal run src/sequin_tool.cr -- verify:chain
-          node scripts/verify_tx.js
+          crystal run src/sequin_tool.cr -- verify:tx
       - name: Commit nightly reward/mint updates
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/rebuild-ledger.yml
+++ b/.github/workflows/rebuild-ledger.yml
@@ -20,9 +20,6 @@ jobs:
       - uses: MeilCli/setup-crystal-action@v4
         with:
           crystal_version: 1.13.2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
       - name: Cache Crystal shards
         uses: actions/cache@v4
         with:
@@ -37,7 +34,7 @@ jobs:
       - name: Verify chain structure
         run: crystal run src/sequin_tool.cr -- verify:chain
       - name: Verify pending tx
-        run: node scripts/verify_tx.js
+        run: crystal run src/sequin_tool.cr -- verify:tx
       - name: Apply new block from pending tx
         run: crystal run src/sequin_tool.cr -- ledger:apply-block
       - name: Commit ledger updates (if any)

--- a/.github/workflows/validate-tx.yml
+++ b/.github/workflows/validate-tx.yml
@@ -7,7 +7,7 @@ on:
       - 'tx/pending/**'
       - 'ledger/state/**'
       - 'schemas/**'
-      - 'scripts/verify_tx.js'
+      - 'src/sequin_tool/commands/verify_tx.cr'
 
 jobs:
   validate:
@@ -21,9 +21,6 @@ jobs:
       - uses: MeilCli/setup-crystal-action@v4
         with:
           crystal_version: 1.13.2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
       - name: Cache Crystal shards
         uses: actions/cache@v4
         with:
@@ -38,4 +35,4 @@ jobs:
       - name: Validate chain structure
         run: crystal run src/sequin_tool.cr -- verify:chain
       - name: Validate pending tx and wallets
-        run: node scripts/verify_tx.js
+        run: crystal run src/sequin_tool.cr -- verify:tx

--- a/MIGRATION_TODO.md
+++ b/MIGRATION_TODO.md
@@ -4,7 +4,7 @@
 
 ## Definition of Done
 
-- [ ] No Node runtime required for core CI/workflows
+- [x] No Node runtime required for core CI/workflows
 - [ ] GitHub-backed ledger flow fully handled by Crystal tooling
 - [ ] Legacy server/miner path removed
 - [ ] Docs reflect one canonical architecture
@@ -117,9 +117,9 @@ Subcommands (empty or stubbed initially):
   - [ ] `tx:sign`
 
 ### 5.2 Tx verifier
-- [ ] Port `scripts/verify_tx.js` to Crystal `verify:tx`
-- [ ] Preserve canonical payload/signature rules
-- [ ] Preserve nonce/balance simulation semantics
+- [x] Port `scripts/verify_tx.js` to Crystal `verify:tx`
+- [x] Preserve canonical payload/signature rules
+- [x] Preserve nonce/balance simulation semantics
 
 ### 5.3 Compatibility checks
 - [ ] Add cross-check tests during migration:
@@ -133,16 +133,18 @@ Subcommands (empty or stubbed initially):
 ## Phase 6 — Workflow Cutover (Node → Crystal)
 
 ### 6.1 Validate tx workflow
-- [x] Replace Node steps with Crystal command invocations in `validate-tx.yml` *(except pending tx verification, still Node until `verify:tx` is ported)*
+- [x] Replace Node steps with Crystal command invocations in `validate-tx.yml`
 
 ### 6.2 Rebuild ledger workflow
-- [x] Replace Node steps with Crystal command invocations in `rebuild-ledger.yml` *(except pending tx verification, still Node until `verify:tx` is ported)*
+- [x] Replace Node steps with Crystal command invocations in `rebuild-ledger.yml`
 
 ### 6.3 Nightly rewards workflow
-- [x] Replace Node steps with Crystal command invocations in `nightly-rewards.yml` *(except tx verification, still Node until `verify:tx` is ported)*
+- [x] Replace Node steps with Crystal command invocations in `nightly-rewards.yml`
 
 ### 6.4 CI ergonomics
 - [x] Add build/cache strategy for Crystal binary to keep workflow duration sane *(shards cache enabled; binary build caching can be layered later)*
+
+**Status note:** validate/rebuild/nightly now run via Crystal `sequin_tool` commands; Node bridge removed from core workflow paths.
 
 **Acceptance:** all three workflows green without `setup-node`.
 

--- a/spec/sequin_tool_spec.cr
+++ b/spec/sequin_tool_spec.cr
@@ -1,3 +1,4 @@
+require "base64"
 require "file_utils"
 require "spec"
 require "json"
@@ -213,6 +214,91 @@ describe SequinTool::CLI do
       out["rewards"].as_a.size.should eq(1)
       out["rewards"].as_a[0].as_h["github"].as_s.should eq("alice")
       out["totals"].as_h["mergedPrCount"].as_i.should eq(1)
+    end
+  end
+
+  it "validates pending tx signatures with verify:tx" do
+    with_tmp_repo do |root|
+      Dir.mkdir_p(File.join(root, "ledger", "state"))
+      Dir.mkdir_p(File.join(root, "wallets"))
+      Dir.mkdir_p(File.join(root, "tx", "pending"))
+
+      File.write(File.join(root, "ledger", "state", "balances.json"), {"alice" => 100, "bob" => 0}.to_pretty_json + "\n")
+      File.write(File.join(root, "ledger", "state", "nonces.json"), {"alice" => 0}.to_pretty_json + "\n")
+
+      key_path = File.join(root, "alice.key.pem")
+      pub_der = File.join(root, "alice.pub.der")
+      status = Process.run("openssl", ["genpkey", "-algorithm", "Ed25519", "-out", key_path])
+      status.success?.should be_true
+      status = Process.run("openssl", ["pkey", "-in", key_path, "-pubout", "-outform", "DER", "-out", pub_der])
+      status.success?.should be_true
+
+      pub_bytes = File.read(pub_der).to_slice
+      pub_bytes.size.should be >= 32
+      raw_pub = pub_bytes[pub_bytes.size - 32, 32]
+      pub_b64 = Base64.strict_encode(raw_pub)
+
+      bob_key_path = File.join(root, "bob.key.pem")
+      bob_pub_der = File.join(root, "bob.pub.der")
+      status = Process.run("openssl", ["genpkey", "-algorithm", "Ed25519", "-out", bob_key_path])
+      status.success?.should be_true
+      status = Process.run("openssl", ["pkey", "-in", bob_key_path, "-pubout", "-outform", "DER", "-out", bob_pub_der])
+      status.success?.should be_true
+      bob_pub_bytes = File.read(bob_pub_der).to_slice
+      bob_pub_bytes.size.should be >= 32
+      bob_pub_b64 = Base64.strict_encode(bob_pub_bytes[bob_pub_bytes.size - 32, 32])
+
+      File.write(File.join(root, "wallets", "alice.json"), {
+        "github" => "alice",
+        "pubkey" => "ed25519:#{pub_b64}",
+        "createdAt" => "2026-03-14T00:00:00Z",
+      }.to_pretty_json + "\n")
+      File.write(File.join(root, "wallets", "bob.json"), {
+        "github" => "bob",
+        "pubkey" => "ed25519:#{bob_pub_b64}",
+        "createdAt" => "2026-03-14T00:00:00Z",
+      }.to_pretty_json + "\n")
+
+      payload = JSON.build do |json|
+        json.object do
+          json.field "id", "tx-1"
+          json.field "from", "alice"
+          json.field "to", "bob"
+          json.field "amount", 10
+          json.field "nonce", 1
+          json.field "sigVersion", 1
+          json.field "memo", ""
+          json.field "createdAt", "2026-03-14T00:00:00Z"
+        end
+      end
+
+      msg_path = File.join(root, "txmsg.json")
+      sig_path = File.join(root, "txsig.bin")
+      File.write(msg_path, payload)
+      status = Process.run("openssl", ["pkeyutl", "-sign", "-inkey", key_path, "-rawin", "-in", msg_path, "-out", sig_path])
+      status.success?.should be_true
+      sig_b64 = Base64.strict_encode(File.read(sig_path).to_slice)
+
+      tx = {
+        "id" => "tx-1",
+        "from" => "alice",
+        "to" => "bob",
+        "amount" => 10,
+        "nonce" => 1,
+        "sigVersion" => 1,
+        "memo" => "",
+        "createdAt" => "2026-03-14T00:00:00Z",
+        "signature" => sig_b64,
+      }
+      File.write(File.join(root, "tx", "pending", "2026-03-14T00-00-00Z__tx-1.json"), tx.to_pretty_json + "\n")
+
+      cli = SequinTool::CLI.new
+      stdout = IO::Memory.new
+      stderr = IO::Memory.new
+
+      cli.run(["verify:tx"], stdout, stderr, root).should eq(0)
+      stdout.to_s.should contain("Validated 1 pending transaction")
+      stderr.to_s.should eq("")
     end
   end
 

--- a/src/sequin_tool/cli.cr
+++ b/src/sequin_tool/cli.cr
@@ -5,6 +5,7 @@ require "./commands/ledger_summary"
 require "./commands/mint_rewards"
 require "./commands/score_epoch"
 require "./commands/verify_chain"
+require "./commands/verify_tx"
 require "./error_handling"
 require "./fs"
 require "./json_io"
@@ -15,7 +16,6 @@ module SequinTool
 
     def initialize
       @commands = [
-        Command.new("verify:tx", "Verify a pending transaction payload.", "Command stub only. Transaction verification will be ported in Phase 5.", "Phase 5", exit_code: 1),
         Command.new("wallet:create", "Create a wallet keypair and public registration payload.", "Command stub only. Wallet creation will be ported in Phase 5.", "Phase 5", exit_code: 1),
         Command.new("tx:next-nonce", "Compute the next nonce for a wallet.", "Command stub only. Nonce lookup will be ported in Phase 5.", "Phase 5", exit_code: 1),
         Command.new("tx:sign", "Sign a transfer payload.", "Command stub only. Transaction signing will be ported in Phase 5.", "Phase 5", exit_code: 1),
@@ -36,6 +36,8 @@ module SequinTool
       case args[0]
       when "verify:chain"
         Commands::VerifyChain.new(stdout, stderr).call(root)
+      when "verify:tx"
+        Commands::VerifyTx.new(stdout, stderr).call(root)
       when "ledger:summary"
         options = parse_ledger_summary_options(args[1..], stderr)
         return 1 unless options
@@ -77,6 +79,7 @@ module SequinTool
       io.puts
       io.puts "Implemented commands:"
       io.puts "  verify:chain          Verify canonical ledger chain state."
+      io.puts "  verify:tx             Validate pending tx and wallet state."
       io.puts "  ledger:summary        Print a ledger summary report."
       io.puts "  ledger:apply-block    Apply pending transactions into ledger state."
       io.puts "  rewards:mint          Mint a reward manifest into ledger state."
@@ -103,6 +106,11 @@ module SequinTool
         stdout.puts "verify:chain - Verify canonical ledger chain state."
         stdout.puts
         stdout.puts "Validates block heights, prevHash linkage, and meta.lastHeight."
+        return 0
+      when "verify:tx"
+        stdout.puts "verify:tx - Validate pending txs and wallet state."
+        stdout.puts
+        stdout.puts "Validates tx schema fields, ids, nonce/balance progression, and Ed25519 signatures."
         return 0
       when "ledger:summary"
         stdout.puts "ledger:summary - Print ledger summary."

--- a/src/sequin_tool/commands/verify_tx.cr
+++ b/src/sequin_tool/commands/verify_tx.cr
@@ -1,0 +1,228 @@
+require "base64"
+require "digest/sha256"
+require "json"
+
+module SequinTool
+  module Commands
+    class VerifyTx
+      PUBKEY_PREFIX = "ed25519:"
+      SPKI_PREFIX = Bytes[0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00]
+
+      def initialize(@stdout : IO = STDOUT, @stderr : IO = STDERR)
+      end
+
+      def call(root : String = Dir.current) : Int32
+        wallets_dir = File.join(root, "wallets")
+        pending_dir = File.join(root, "tx", "pending")
+        balances_path = File.join(root, "ledger", "state", "balances.json")
+        nonces_path = File.join(root, "ledger", "state", "nonces.json")
+
+        balances = read_numeric_hash(balances_path)
+        nonces = read_numeric_hash(nonces_path)
+
+        wallet_files = list_json_files(wallets_dir)
+        wallets = Hash(String, Hash(String, JSON::Any)).new
+        pubkeys = Set(String).new
+
+        wallet_files.each do |wf|
+          wallet = JSON.parse(File.read(wf)).as_h
+          github = wallet["github"]?.try(&.as_s) || fail!("#{File.basename(wf)}: missing github")
+          pubkey = wallet["pubkey"]?.try(&.as_s) || fail!("#{File.basename(wf)}: missing pubkey")
+
+          filename = File.basename(wf, ".json")
+          fail!("Wallet filename #{filename}.json must match github field #{github}") unless filename == github
+          fail!("Duplicate wallet for #{github}") if wallets.has_key?(github)
+          fail!("Duplicate public key for #{github}") if pubkeys.includes?(pubkey)
+
+          validate_pubkey(pubkey, github)
+
+          wallets[github] = wallet
+          pubkeys << pubkey
+        end
+
+        @stdout.puts "✅ Loaded #{wallets.size} wallet(s)"
+
+        tx_files = list_json_files(pending_dir)
+        tx_ids = Set(String).new
+        tx_hashes = Set(String).new
+
+        tx_files.each do |tf|
+          tx = JSON.parse(File.read(tf)).as_h
+          ctx = File.basename(tf)
+
+          required = ["id", "from", "to", "amount", "nonce", "sigVersion", "createdAt", "signature"]
+          required.each do |key|
+            fail!("#{ctx}: missing #{key}") unless tx.has_key?(key)
+          end
+
+          id = tx["id"].as_s
+          fail!("#{ctx}: duplicate tx id #{id}") if tx_ids.includes?(id)
+          tx_ids << id
+
+          hash = tx_hash(tx)
+          fail!("#{ctx}: duplicate tx payload hash #{hash}") if tx_hashes.includes?(hash)
+          tx_hashes << hash
+
+          from = tx["from"].as_s
+          to = tx["to"].as_s
+          amount = int_value(tx["amount"], "#{ctx}: amount")
+          nonce = int_value(tx["nonce"], "#{ctx}: nonce")
+          sig_version = int_value(tx["sigVersion"], "#{ctx}: sigVersion")
+
+          fail!("#{ctx}: sender wallet #{from} not registered") unless wallets.has_key?(from)
+          fail!("#{ctx}: receiver wallet #{to} not registered") unless wallets.has_key?(to)
+          fail!("#{ctx}: amount must be integer >= 1") unless amount >= 1
+          fail!("#{ctx}: nonce must be integer >= 1") unless nonce >= 1
+          fail!("#{ctx}: sigVersion must be 1") unless sig_version == 1
+
+          expected_nonce = (nonces[from]? || 0_i64) + 1
+          if nonce != expected_nonce
+            fail!("#{ctx}: nonce mismatch for #{from}; expected #{expected_nonce}, got #{nonce}")
+          end
+
+          balance = balances[from]? || 0_i64
+          if balance < amount
+            fail!("#{ctx}: insufficient funds for #{from}; have #{balance}, need #{amount}")
+          end
+
+          verify_signature!(tx, wallets[from], ctx)
+
+          nonces[from] = nonce
+          balances[from] = balance - amount
+          balances[to] = (balances[to]? || 0_i64) + amount
+        end
+
+        @stdout.puts "✅ Validated #{tx_files.size} pending transaction(s)"
+        0
+      rescue ex : CLIError
+        ErrorHandling.handle(@stderr, ex)
+      rescue ex
+        ErrorHandling.handle(@stderr, ex)
+      end
+
+      private def list_json_files(dir : String) : Array(String)
+        return [] of String unless Dir.exists?(dir)
+        Dir.children(dir).select(&.ends_with?(".json")).sort.map { |f| File.join(dir, f) }
+      end
+
+      private def read_numeric_hash(path : String) : Hash(String, Int64)
+        return {} of String => Int64 unless File.exists?(path)
+        json = JSON.parse(File.read(path)).as_h
+        out = Hash(String, Int64).new
+        json.each do |k, v|
+          out[k] = int_value(v, "#{path}:#{k}")
+        end
+        out
+      end
+
+      private def int_value(value : JSON::Any, context : String) : Int64
+        raw = value.raw
+        case raw
+        when Int64
+          raw
+        when Float64
+          raw.to_i64
+        else
+          fail!("#{context} must be integer")
+        end
+      end
+
+      private def tx_hash(tx : Hash(String, JSON::Any)) : String
+        Digest::SHA256.hexdigest(canonical_tx_string(tx))
+      end
+
+      private def canonical_tx_string(tx : Hash(String, JSON::Any)) : String
+        JSON.build do |json|
+          json.object do
+            json.field "id", tx["id"].as_s
+            json.field "from", tx["from"].as_s
+            json.field "to", tx["to"].as_s
+            json.field "amount", int_value(tx["amount"], "amount")
+            json.field "nonce", int_value(tx["nonce"], "nonce")
+            json.field "sigVersion", int_value(tx["sigVersion"], "sigVersion")
+            json.field "memo", tx["memo"]?.try(&.as_s) || ""
+            json.field "createdAt", tx["createdAt"].as_s
+          end
+        end
+      end
+
+      private def validate_pubkey(pubkey : String, github : String)
+        unless pubkey.starts_with?(PUBKEY_PREFIX)
+          fail!("Invalid pubkey for #{github}: pubkey must be prefixed with ed25519:")
+        end
+
+        b64 = pubkey[PUBKEY_PREFIX.size..-1]
+        raw = Base64.decode(b64)
+        unless raw.size == 32
+          fail!("Invalid pubkey for #{github}: ed25519 public key must decode to 32 bytes")
+        end
+      rescue ex
+        fail!("Invalid pubkey for #{github}: #{ex.message}")
+      end
+
+      private def verify_signature!(tx : Hash(String, JSON::Any), wallet : Hash(String, JSON::Any), ctx : String)
+        pubkey = wallet["pubkey"].as_s
+        sig_b64 = tx["signature"].as_s
+
+        b64 = pubkey[PUBKEY_PREFIX.size..-1]
+        raw_key = Base64.decode(b64)
+        signature = Base64.decode(sig_b64)
+
+        unless signature.size == 64
+          fail!("#{ctx}: signature verification error: signature must decode to 64 bytes (ed25519)")
+        end
+
+        spki_der = Bytes.new(SPKI_PREFIX.size + raw_key.size)
+        SPKI_PREFIX.each_with_index { |byte, idx| spki_der[idx] = byte }
+        raw_key.each_with_index { |byte, idx| spki_der[SPKI_PREFIX.size + idx] = byte }
+
+        payload = canonical_tx_string(tx)
+
+        pub_file = File.tempfile("sequin-pub")
+        sig_file = File.tempfile("sequin-sig")
+        msg_file = File.tempfile("sequin-msg")
+
+        begin
+          pub_file.write(spki_der)
+          sig_file.write(signature)
+          msg_file << payload
+          pub_file.flush
+          sig_file.flush
+          msg_file.flush
+
+          output = IO::Memory.new
+          err = IO::Memory.new
+          status = Process.run(
+            "openssl",
+            [
+              "pkeyutl",
+              "-verify",
+              "-pubin",
+              "-inkey", pub_file.path,
+              "-keyform", "DER",
+              "-rawin",
+              "-in", msg_file.path,
+              "-sigfile", sig_file.path,
+            ],
+            output: output,
+            error: err
+          )
+
+          unless status.success?
+            fail!("#{ctx}: signature verification failed")
+          end
+        rescue ex
+          fail!("#{ctx}: signature verification error: #{ex.message}")
+        ensure
+          pub_file.close
+          sig_file.close
+          msg_file.close
+        end
+      end
+
+      private def fail!(message : String) : NoReturn
+        raise CLIError.new("❌ #{message}", exit_code: 1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- implement Crystal `verify:tx` command in `sequin_tool` with parity to JS validator behavior:
  - wallet filename/pubkey validation
  - duplicate wallet/pubkey checks
  - tx required fields and duplicate id/hash checks
  - nonce and balance simulation over pending tx ordering
  - canonical payload hashing
  - Ed25519 signature verification (via `openssl pkeyutl` with SPKI DER pubkey)
- wire CLI routing/help for `verify:tx`
- switch core workflows to Crystal `verify:tx` and remove Node from core paths:
  - `validate-tx.yml`
  - `rebuild-ledger.yml`
  - `nightly-rewards.yml`
- update validate workflow path triggers from JS verifier to Crystal verifier source
- add integration spec for verify:tx using generated Ed25519 key/signature fixtures
- update `MIGRATION_TODO.md` progress for Phase 5.2 + Phase 6 status

## Testing
- `shards install`
- `crystal spec`
