### PR TITLE
feat(crypto): finalize secp256k1 wallet/tx flow for GitHub-native Sequin

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+-
+
+## Validation
+
+-
+
+## SIP impact
+
+- [ ] This PR changes protocol/validation/rewards/crypto behavior.
+- [ ] If checked, linked SIP: `SIP-____` (or explain why a SIP is not needed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+### Migration
+
+- Finalized crypto direction for the GitHub-native Crystal flow: `secp256k1` (prototype-first, no backward-compatibility requirement).
+- Migrated wallet generation, tx signing, and tx verification in `sequin_tool` from Ed25519/OpenSSL shell calls to native Crystal secp256k1 usage.
+- Updated wallet schema and usage docs to the secp format:
+  - `pubkey`: `secp256k1:<compressed-pubkey-hex>`
+  - `signature`: `secp256k1:<r_hex>:<s_hex>`
+- Added/updated tests to validate secp256k1 signing + verification flow.
+- Executed full Crystal-only lifecycle dry run in isolated temp repo (wallet create, tx sign/apply, score/mint, verify/summary).
+
 # [1.12.0](https://github.com/LucianBuzzo/sequin/compare/v1.11.0...v1.12.0) (2021-03-06)
 
 

--- a/GITHUB_NATIVE_USAGE.md
+++ b/GITHUB_NATIVE_USAGE.md
@@ -21,7 +21,7 @@ Create `wallets/<your-github-username>.json`:
 ```json
 {
   "github": "your-username",
-  "pubkey": "ed25519:BASE64_PUBKEY",
+  "pubkey": "secp256k1:COMPRESSED_PUBKEY_HEX",
   "createdAt": "2026-03-13T12:00:00Z"
 }
 ```
@@ -51,7 +51,7 @@ Open a PR containing that tx file.
   "sigVersion": 1,
   "memo": "hello sequin",
   "createdAt": "2026-03-13T12:05:00Z",
-  "signature": "BASE64_SIG"
+  "signature": "secp256k1:R_HEX:S_HEX"
 }
 ```
 
@@ -62,7 +62,7 @@ Open a PR containing that tx file.
   - registered sender/receiver wallets
   - nonce progression (`current + 1`)
   - sufficient sender balance
-  - Ed25519 signature against canonical payload
+  - secp256k1 signature against canonical payload
 - after merge, `rebuild-ledger` applies pending tx into a new block and updates balances/nonces.
 
 ### Nonce collision policy

--- a/MIGRATION_TODO.md
+++ b/MIGRATION_TODO.md
@@ -14,9 +14,10 @@
 ## Phase 0 — Foundations
 
 ### 0.1 Decide crypto path (blocking)
-- [ ] Choose and record signature standard:
+- [x] Choose and record signature standard:
   - [ ] Keep Ed25519 (preferred for compatibility)
-  - [ ] OR migrate to secp256k1 (breaking format change)
+  - [x] OR migrate to secp256k1 (breaking format change)
+- [x] Decision captured (2026-03-15): prototype path will use `secp256k1`; backward compatibility not required.
 
 **Acceptance:** decision documented in README + this file.
 
@@ -162,7 +163,7 @@ Subcommands (empty or stubbed initially):
 
 ### 7.3 Docs cleanup
 - [x] Update README to single canonical architecture
-- [ ] Add migration notes/changelog entries
+- [x] Add migration notes/changelog entries
 
 **Acceptance:** repo has one runtime model (Crystal + GitHub-backed workflows).
 
@@ -176,6 +177,8 @@ Run end-to-end in dry run and real flow:
 - [ ] Transfer tx PR + block apply
 - [ ] Nightly score + mint epoch
 - [ ] Ledger verify + summary outputs
+
+**Status note (2026-03-15):** Dry-run lifecycle executed successfully in an isolated temp repo using Crystal-only commands (`wallet:create`, `tx:sign`, `verify:tx`, `ledger:apply-block`, `rewards:score-epoch`, `rewards:mint`, `verify:chain`, `ledger:summary`). Real PR-backed flow remains pending.
 
 **Acceptance:** full lifecycle works with Crystal-only command path.
 

--- a/README.md
+++ b/README.md
@@ -138,3 +138,4 @@ crystal run src/sequin_tool.cr -- repo:lint
 - `AGENTS.md` (project field notes + guardrails)
 - `GITHUB_NATIVE_SEQUIN_PLAN.md`
 - `GITHUB_NATIVE_USAGE.md`
+- `sips/README.md` + `sips/SIP_TEMPLATE.md` (Sequin Improvement Proposal process/template)

--- a/schemas/wallet.schema.json
+++ b/schemas/wallet.schema.json
@@ -14,7 +14,7 @@
     "pubkey": {
       "type": "string",
       "minLength": 16,
-      "pattern": "^ed25519:[A-Za-z0-9+/=]+$"
+      "pattern": "^secp256k1:(02|03)[0-9a-fA-F]{64}$"
     },
     "createdAt": {
       "type": "string",

--- a/sips/README.md
+++ b/sips/README.md
@@ -1,0 +1,39 @@
+# Sequin Improvement Proposals (SIPs)
+
+SIPs are design docs for meaningful changes to Sequin.
+
+This process is inspired by Ethereum's EIP process, adapted for Sequin's repo-native workflow.
+
+## When to write a SIP
+
+Write a SIP for changes that affect:
+
+- protocol/validation behavior
+- ledger formats or transaction rules
+- wallet/signature formats
+- reward scoring/minting policy
+- governance/process expectations
+
+If a change is small and local (e.g., typo, non-behavioral refactor), a normal PR is enough.
+
+## Workflow
+
+1. Copy `sips/SIP_TEMPLATE.md` to `sips/SIP-XXXX-<slug>.md`
+2. Open a PR with `Status: Draft`
+3. Gather discussion in PR/issue/discussion (link via `Discussions-To`)
+4. Move to `Review` when spec is implementation-ready
+5. Mark `Final` when merged and adopted
+
+Suggested status lifecycle:
+
+`Draft -> Review -> Final` (or `Withdrawn`/`Superseded`)
+
+## Numbering
+
+- Use `SIP-XXXX` with zero-padded integer IDs.
+- First accepted SIP can start at `SIP-0001`.
+- Reserve an ID in the PR title/body to avoid collisions.
+
+## Template
+
+Use: `sips/SIP_TEMPLATE.md`

--- a/sips/README.md
+++ b/sips/README.md
@@ -37,3 +37,7 @@ Suggested status lifecycle:
 ## Template
 
 Use: `sips/SIP_TEMPLATE.md`
+
+## First SIP
+
+- `sips/SIP-0001-process-and-statuses.md` defines the baseline SIP governance process.

--- a/sips/SIP-0001-process-and-statuses.md
+++ b/sips/SIP-0001-process-and-statuses.md
@@ -1,0 +1,103 @@
+# SIP-0001: Sequin Improvement Proposal Process and Statuses
+
+- **SIP**: SIP-0001
+- **Title**: Sequin Improvement Proposal Process and Statuses
+- **Author**: Gravious (@gravious)
+- **Discussions-To**: https://github.com/LucianBuzzo/sequin/pull/43
+- **Status**: Final
+- **Type**: Meta
+- **Category**: Governance
+- **Created**: 2026-03-15
+- **Requires**: (none)
+- **Replaces**: (none)
+- **Superseded-By**: (none)
+
+---
+
+## Abstract
+
+This SIP defines the baseline SIP process for Sequin: when a SIP is required, how SIPs are numbered, which statuses they move through, and what minimum fields every SIP must contain. The process is inspired by Ethereum's EIP process but intentionally simplified for Sequin's size and repo-native workflow.
+
+## Motivation
+
+Sequin now has protocol-critical behavior (transaction validation, signing formats, ledger/state transitions, and reward minting policies). Without a lightweight governance document process, these decisions can become fragmented across PR comments and ad hoc docs, making future maintenance harder.
+
+A SIP process creates a stable, searchable design history and raises the quality bar for high-impact changes.
+
+## Specification
+
+### 1. SIP required changes
+
+A SIP SHOULD be used for changes affecting:
+
+- protocol/validation behavior
+- ledger or tx data formats
+- wallet/signature formats
+- reward scoring or minting policy
+- governance/process rules
+
+Small local changes (typos, isolated refactors with no behavior impact) MAY proceed without a SIP.
+
+### 2. File location and format
+
+- SIPs live under `sips/`
+- Naming convention: `sips/SIP-XXXX-<slug>.md`
+- SIPs MUST use the canonical template from `sips/SIP_TEMPLATE.md`
+
+### 3. Numbering
+
+- IDs are zero-padded integers: `SIP-0001`, `SIP-0002`, ...
+- New SIPs reserve an ID in their opening PR to avoid collisions.
+
+### 4. Status lifecycle
+
+Canonical statuses:
+
+- `Draft`: initial proposal and active iteration
+- `Review`: implementation-ready and seeking maintainers' decision
+- `Final`: accepted and merged/adopted
+- `Withdrawn`: intentionally abandoned
+- `Superseded`: replaced by a newer SIP
+
+### 5. Process
+
+1. Copy `sips/SIP_TEMPLATE.md` to a numbered SIP file.
+2. Open PR with `Status: Draft`.
+3. Discuss in linked PR/issue/discussion via `Discussions-To`.
+4. Move to `Review` when spec is implementation-ready.
+5. Move to `Final` once accepted and merged.
+
+## Rationale
+
+This process chooses a minimal lifecycle over a complex standards taxonomy. Sequin benefits more from consistency and low-friction participation than from heavyweight ceremony.
+
+## Backwards Compatibility
+
+This is a governance/process SIP and introduces no runtime behavior changes.
+
+## Security Considerations
+
+A formal SIP process helps surface security concerns earlier by requiring explicit security sections for high-impact changes.
+
+## Testing
+
+No runtime tests required. Conformance is process-based and validated by:
+
+- SIP file presence and format
+- template usage
+- linked discussion and status transitions
+
+## Reference Implementation (optional)
+
+- `sips/README.md`
+- `sips/SIP_TEMPLATE.md`
+- `sips/SIP-0001-process-and-statuses.md`
+
+## Rollout Plan
+
+- Adopt this SIP immediately as baseline governance.
+- Require SIP linkage in PRs that touch protocol/validation/rewards/crypto.
+
+## Copyright
+
+This document is licensed under CC0-1.0.

--- a/sips/SIP_TEMPLATE.md
+++ b/sips/SIP_TEMPLATE.md
@@ -1,0 +1,68 @@
+# SIP-XXXX: <short title>
+
+- **SIP**: SIP-XXXX
+- **Title**: <short title>
+- **Author**: <name> (@github-handle)
+- **Discussions-To**: <GitHub issue/discussion link>
+- **Status**: Draft
+- **Type**: Standards Track | Process | Meta
+- **Category**: Core | Ledger | Wallet | Rewards | Governance | Tooling
+- **Created**: YYYY-MM-DD
+- **Requires**: SIP-XXXX, SIP-YYYY (optional)
+- **Replaces**: SIP-XXXX (optional)
+- **Superseded-By**: SIP-XXXX (optional)
+
+---
+
+## Abstract
+
+A short (~200 words max) technical summary of the proposal.
+
+## Motivation
+
+Why is this needed? What problem are we solving, and for whom?
+
+## Specification
+
+Describe the proposal in enough detail that someone else can implement it.
+
+Include:
+
+- data model / schema changes
+- command / workflow changes
+- consensus or validation impacts
+- error handling and edge cases
+
+## Rationale
+
+Explain design decisions and trade-offs.
+
+## Backwards Compatibility
+
+- Is this breaking?
+- What existing behavior changes?
+- Migration strategy (if any)
+
+## Security Considerations
+
+New attack surfaces, abuse vectors, and mitigations.
+
+## Testing
+
+- unit/integration cases
+- deterministic fixtures
+- failure cases
+
+## Reference Implementation (optional)
+
+Link PR(s), branches, or pseudocode.
+
+## Rollout Plan
+
+- implementation steps
+- feature flags / guards
+- release or deployment sequence
+
+## Copyright
+
+This document is licensed under CC0-1.0.

--- a/spec/sequin_tool_spec.cr
+++ b/spec/sequin_tool_spec.cr
@@ -2,6 +2,7 @@ require "base64"
 require "file_utils"
 require "spec"
 require "json"
+require "secp256k1"
 require "../src/sequin_tool/cli"
 require "../src/sequin_tool/commands/score_epoch"
 
@@ -226,36 +227,20 @@ describe SequinTool::CLI do
       File.write(File.join(root, "ledger", "state", "balances.json"), {"alice" => 100, "bob" => 0}.to_pretty_json + "\n")
       File.write(File.join(root, "ledger", "state", "nonces.json"), {"alice" => 0}.to_pretty_json + "\n")
 
-      key_path = File.join(root, "alice.key.pem")
-      pub_der = File.join(root, "alice.pub.der")
-      status = Process.run("openssl", ["genpkey", "-algorithm", "Ed25519", "-out", key_path])
-      status.success?.should be_true
-      status = Process.run("openssl", ["pkey", "-in", key_path, "-pubout", "-outform", "DER", "-out", pub_der])
-      status.success?.should be_true
+      alice_key = Secp256k1::Keypair.new
+      bob_key = Secp256k1::Keypair.new
 
-      pub_bytes = File.read(pub_der).to_slice
-      pub_bytes.size.should be >= 32
-      raw_pub = pub_bytes[pub_bytes.size - 32, 32]
-      pub_b64 = Base64.strict_encode(raw_pub)
-
-      bob_key_path = File.join(root, "bob.key.pem")
-      bob_pub_der = File.join(root, "bob.pub.der")
-      status = Process.run("openssl", ["genpkey", "-algorithm", "Ed25519", "-out", bob_key_path])
-      status.success?.should be_true
-      status = Process.run("openssl", ["pkey", "-in", bob_key_path, "-pubout", "-outform", "DER", "-out", bob_pub_der])
-      status.success?.should be_true
-      bob_pub_bytes = File.read(bob_pub_der).to_slice
-      bob_pub_bytes.size.should be >= 32
-      bob_pub_b64 = Base64.strict_encode(bob_pub_bytes[bob_pub_bytes.size - 32, 32])
+      alice_pub = Secp256k1::Util.public_key_compressed_prefix(alice_key.public_key)
+      bob_pub = Secp256k1::Util.public_key_compressed_prefix(bob_key.public_key)
 
       File.write(File.join(root, "wallets", "alice.json"), {
         "github" => "alice",
-        "pubkey" => "ed25519:#{pub_b64}",
+        "pubkey" => "secp256k1:#{alice_pub}",
         "createdAt" => "2026-03-14T00:00:00Z",
       }.to_pretty_json + "\n")
       File.write(File.join(root, "wallets", "bob.json"), {
         "github" => "bob",
-        "pubkey" => "ed25519:#{bob_pub_b64}",
+        "pubkey" => "secp256k1:#{bob_pub}",
         "createdAt" => "2026-03-14T00:00:00Z",
       }.to_pretty_json + "\n")
 
@@ -272,12 +257,8 @@ describe SequinTool::CLI do
         end
       end
 
-      msg_path = File.join(root, "txmsg.json")
-      sig_path = File.join(root, "txsig.bin")
-      File.write(msg_path, payload)
-      status = Process.run("openssl", ["pkeyutl", "-sign", "-inkey", key_path, "-rawin", "-in", msg_path, "-out", sig_path])
-      status.success?.should be_true
-      sig_b64 = Base64.strict_encode(File.read(sig_path).to_slice)
+      sig = Secp256k1::Signature.sign(payload, alice_key.private_key)
+      sig_b64 = "secp256k1:#{Secp256k1::Util.to_padded_hex_32(sig.r)}:#{Secp256k1::Util.to_padded_hex_32(sig.s)}"
 
       tx = {
         "id" => "tx-1",

--- a/src/sequin_tool/cli.cr
+++ b/src/sequin_tool/cli.cr
@@ -134,10 +134,10 @@ module SequinTool
       when "verify:tx"
         stdout.puts "verify:tx - Validate pending txs and wallet state."
         stdout.puts
-        stdout.puts "Validates tx schema fields, ids, nonce/balance progression, and Ed25519 signatures."
+        stdout.puts "Validates tx schema fields, ids, nonce/balance progression, and secp256k1 signatures."
         return 0
       when "wallet:create"
-        stdout.puts "wallet:create - Create local Ed25519 keypair + wallet JSON."
+        stdout.puts "wallet:create - Create local secp256k1 keypair + wallet JSON."
         stdout.puts
         stdout.puts "Options: --github <username>"
         return 0

--- a/src/sequin_tool/commands/tx_sign.cr
+++ b/src/sequin_tool/commands/tx_sign.cr
@@ -1,5 +1,5 @@
-require "base64"
 require "json"
+require "secp256k1"
 
 module SequinTool
   module Commands
@@ -32,9 +32,9 @@ module SequinTool
         }
 
         payload = canonical_tx_json(tx)
-        sig = sign_payload(payload, key_path)
+        signature = sign_payload(payload, key_path)
 
-        tx["signature"] = JSON::Any.new(Base64.strict_encode(sig))
+        tx["signature"] = JSON::Any.new(signature)
 
         stamp = created_at.gsub(/[:.]/, "-")
         out_path = File.join(pending_dir, "#{stamp}__#{tx_id}.json")
@@ -60,33 +60,18 @@ module SequinTool
         end
       end
 
-      private def sign_payload(payload : String, key_path : String) : Bytes
-        msg_path = File.join(Dir.tempdir, "sequin-#{Random::Secure.hex(6)}.msg")
-        sig_path = File.join(Dir.tempdir, "sequin-#{Random::Secure.hex(6)}.sig")
+      private def sign_payload(payload : String, key_path : String) : String
+        private_key_hex = File.read(key_path).strip
+        raise CLIError.new("Invalid private key hex", exit_code: 1) if private_key_hex.empty?
 
-        begin
-          File.write(msg_path, payload)
-          output = IO::Memory.new
-          error = IO::Memory.new
-          status = Process.run(
-            "openssl",
-            ["pkeyutl", "-sign", "-inkey", key_path, "-rawin", "-in", msg_path, "-out", sig_path],
-            output: output,
-            error: error
-          )
+        private_key = BigInt.new(private_key_hex, 16)
+        sig = Secp256k1::Signature.sign(payload, private_key)
 
-          unless status.success?
-            err_s = error.to_s
-            out_s = output.to_s
-            msg = !err_s.empty? ? err_s : (!out_s.empty? ? out_s : "command failed")
-            raise CLIError.new("openssl signing failed: #{msg}", exit_code: 1)
-          end
-
-          File.read(sig_path).to_slice
-        ensure
-          File.delete?(msg_path)
-          File.delete?(sig_path)
-        end
+        r_hex = Secp256k1::Util.to_padded_hex_32(sig.r)
+        s_hex = Secp256k1::Util.to_padded_hex_32(sig.s)
+        "secp256k1:#{r_hex}:#{s_hex}"
+      rescue ex
+        raise CLIError.new("Failed to sign payload: #{ex.message}", exit_code: 1)
       end
     end
   end

--- a/src/sequin_tool/commands/verify_tx.cr
+++ b/src/sequin_tool/commands/verify_tx.cr
@@ -1,12 +1,12 @@
-require "base64"
 require "digest/sha256"
 require "json"
+require "secp256k1"
 
 module SequinTool
   module Commands
     class VerifyTx
-      PUBKEY_PREFIX = "ed25519:"
-      SPKI_PREFIX = Bytes[0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00]
+      PUBKEY_PREFIX = "secp256k1:"
+      SIGNATURE_PREFIX = "secp256k1:"
 
       def initialize(@stdout : IO = STDOUT, @stderr : IO = STDERR)
       end
@@ -148,76 +148,43 @@ module SequinTool
 
       private def validate_pubkey(pubkey : String, github : String)
         unless pubkey.starts_with?(PUBKEY_PREFIX)
-          fail!("Invalid pubkey for #{github}: pubkey must be prefixed with ed25519:")
+          fail!("Invalid pubkey for #{github}: pubkey must be prefixed with secp256k1:")
         end
 
-        b64 = pubkey[PUBKEY_PREFIX.size..-1]
-        raw = Base64.decode(b64)
-        unless raw.size == 32
-          fail!("Invalid pubkey for #{github}: ed25519 public key must decode to 32 bytes")
+        encoded = pubkey[PUBKEY_PREFIX.size..-1]
+        unless encoded.matches?(/\A(02|03)[0-9a-fA-F]{64}\z/)
+          fail!("Invalid pubkey for #{github}: expected compressed secp256k1 pubkey hex")
         end
-      rescue ex
-        fail!("Invalid pubkey for #{github}: #{ex.message}")
       end
 
       private def verify_signature!(tx : Hash(String, JSON::Any), wallet : Hash(String, JSON::Any), ctx : String)
-        pubkey = wallet["pubkey"].as_s
-        sig_b64 = tx["signature"].as_s
-
-        b64 = pubkey[PUBKEY_PREFIX.size..-1]
-        raw_key = Base64.decode(b64)
-        signature = Base64.decode(sig_b64)
-
-        unless signature.size == 64
-          fail!("#{ctx}: signature verification error: signature must decode to 64 bytes (ed25519)")
-        end
-
-        spki_der = Bytes.new(SPKI_PREFIX.size + raw_key.size)
-        SPKI_PREFIX.each_with_index { |byte, idx| spki_der[idx] = byte }
-        raw_key.each_with_index { |byte, idx| spki_der[SPKI_PREFIX.size + idx] = byte }
-
+        pubkey = wallet["pubkey"].as_s[PUBKEY_PREFIX.size..-1]
+        signature = tx["signature"].as_s
         payload = canonical_tx_string(tx)
 
-        pub_file = File.tempfile("sequin-pub")
-        sig_file = File.tempfile("sequin-sig")
-        msg_file = File.tempfile("sequin-msg")
-
-        begin
-          pub_file.write(spki_der)
-          sig_file.write(signature)
-          msg_file << payload
-          pub_file.flush
-          sig_file.flush
-          msg_file.flush
-
-          output = IO::Memory.new
-          err = IO::Memory.new
-          status = Process.run(
-            "openssl",
-            [
-              "pkeyutl",
-              "-verify",
-              "-pubin",
-              "-inkey", pub_file.path,
-              "-keyform", "DER",
-              "-rawin",
-              "-in", msg_file.path,
-              "-sigfile", sig_file.path,
-            ],
-            output: output,
-            error: err
-          )
-
-          unless status.success?
-            fail!("#{ctx}: signature verification failed")
-          end
-        rescue ex
-          fail!("#{ctx}: signature verification error: #{ex.message}")
-        ensure
-          pub_file.close
-          sig_file.close
-          msg_file.close
+        unless signature.starts_with?(SIGNATURE_PREFIX)
+          fail!("#{ctx}: signature must be prefixed with secp256k1:")
         end
+
+        parts = signature[SIGNATURE_PREFIX.size..-1].split(":")
+        unless parts.size == 2
+          fail!("#{ctx}: signature must be formatted as secp256k1:<r_hex>:<s_hex>")
+        end
+
+        r_hex, s_hex = parts
+        unless r_hex.matches?(/\A[0-9a-fA-F]{64}\z/) && s_hex.matches?(/\A[0-9a-fA-F]{64}\z/)
+          fail!("#{ctx}: signature r/s must be 64-char hex values")
+        end
+
+        sig = Secp256k1::ECDSASignature.new(BigInt.new(r_hex, 16), BigInt.new(s_hex, 16))
+        point = Secp256k1::Util.restore_public_key(pubkey)
+
+        valid = Secp256k1::Signature.verify(payload, sig, point)
+        fail!("#{ctx}: signature verification failed") unless valid
+      rescue ex : CLIError
+        raise ex
+      rescue ex
+        fail!("#{ctx}: signature verification error: #{ex.message}")
       end
 
       private def fail!(message : String) : NoReturn

--- a/src/sequin_tool/commands/wallet_create.cr
+++ b/src/sequin_tool/commands/wallet_create.cr
@@ -1,5 +1,5 @@
-require "base64"
 require "json"
+require "secp256k1"
 
 module SequinTool
   module Commands
@@ -18,46 +18,25 @@ module SequinTool
           raise CLIError.new("Private key already exists: #{key_path}", exit_code: 1)
         end
 
-        pub_der_path = File.join(Dir.tempdir, "sequin-#{Random::Secure.hex(6)}.pub.der")
+        keypair = Secp256k1::Keypair.new
+        private_key_hex = keypair.get_secret
+        public_key_hex = Secp256k1::Util.public_key_compressed_prefix(keypair.public_key)
 
-        begin
-          run!("openssl", ["genpkey", "-algorithm", "Ed25519", "-out", key_path])
-          run!("openssl", ["pkey", "-in", key_path, "-pubout", "-outform", "DER", "-out", pub_der_path])
+        File.write(key_path, private_key_hex + "\n")
 
-          pub_bytes = File.read(pub_der_path).to_slice
-          raise CLIError.new("Unexpected pubkey length", exit_code: 1) if pub_bytes.size < 32
+        wallet = {
+          "github"    => JSON::Any.new(github),
+          "pubkey"    => JSON::Any.new("secp256k1:#{public_key_hex}"),
+          "createdAt" => JSON::Any.new(Time.utc.to_rfc3339),
+        }
 
-          raw_pub = pub_bytes[pub_bytes.size - 32, 32]
-          pub_b64 = Base64.strict_encode(raw_pub)
+        wallet_path = File.join(wallets_dir, "#{github}.json")
+        File.write(wallet_path, JSON::Any.new(wallet).to_pretty_json + "\n")
 
-          wallet = {
-            "github"    => JSON::Any.new(github),
-            "pubkey"    => JSON::Any.new("ed25519:#{pub_b64}"),
-            "createdAt" => JSON::Any.new(Time.utc.to_rfc3339),
-          }
-
-          wallet_path = File.join(wallets_dir, "#{github}.json")
-          File.write(wallet_path, JSON::Any.new(wallet).to_pretty_json + "\n")
-
-          @stdout.puts "✅ Created wallet file: #{wallet_path}"
-          @stdout.puts "✅ Created private key: #{key_path}"
-          @stdout.puts "⚠️ Keep private key secret. Do NOT commit .sequin/keys/*"
-          0
-        ensure
-          File.delete?(pub_der_path)
-        end
-      end
-
-      private def run!(command : String, args : Array(String))
-        output = IO::Memory.new
-        error = IO::Memory.new
-        status = Process.run(command, args, output: output, error: error)
-        unless status.success?
-          err_s = error.to_s
-          out_s = output.to_s
-          msg = !err_s.empty? ? err_s : (!out_s.empty? ? out_s : "command failed")
-          raise CLIError.new("#{command} #{args.join(" ")} failed: #{msg}", exit_code: 1)
-        end
+        @stdout.puts "✅ Created wallet file: #{wallet_path}"
+        @stdout.puts "✅ Created private key: #{key_path}"
+        @stdout.puts "⚠️ Keep private key secret. Do NOT commit .sequin/keys/*"
+        0
       end
     end
   end


### PR DESCRIPTION
## Summary
- switch Sequin wallet + tx cryptography in `sequin_tool` from Ed25519/OpenSSL shell calls to native Crystal `secp256k1`
- update tx verification and wallet schema to secp formats
- update migration/docs/changelog notes for finalized crypto decision
- add secp-based spec coverage for signing + verification flow

## What changed
- `wallet:create`
  - now generates secp256k1 keys via Crystal lib
  - stores private key hex in `.sequin/keys/<user>.key`
  - writes wallet pubkey as `secp256k1:<compressed_pubkey_hex>`
- `tx:sign`
  - now emits `signature` as `secp256k1:<r_hex>:<s_hex>`
- `verify:tx`
  - validates secp wallet prefix/format and signature tuple format
  - verifies ECDSA signature using secp256k1 public key restore + verify
- `schemas/wallet.schema.json`
  - pubkey pattern updated to secp compressed form
- docs updated:
  - `GITHUB_NATIVE_USAGE.md`
  - `MIGRATION_TODO.md`
  - `CHANGELOG.md` (Unreleased migration notes)

## Validation
- `crystal spec` ✅ (22 examples, 0 failures)
- `crystal run src/sequin_tool.cr -- repo:lint` ✅
- phase-8 style dry run executed in isolated temp repo for Crystal-only flow:
  - wallet create
  - tx sign + verify + apply block
  - score epoch + mint rewards
  - verify chain + ledger summary

## Notes
- This locks the prototype crypto decision to secp256k1 as agreed.
- Real PR-backed E2E on `master` remains tracked in `MIGRATION_TODO.md`.
