### PR TITLE
Add Justfile target for running a single spec file

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -4,10 +4,14 @@ set shell := ["bash", "-cu"]
 all:
   ./sequin
 
-# Run test suite
+# Run full test suite
 
 test:
   crystal spec
+
+# Run a single spec file, e.g. `just test-file spec/cli_spec.cr`
+test-file spec_file:
+  crystal spec {{spec_file}}
 
 # Build local binary
 build:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ just install-local
 ### Validation commands
 
 ```bash
+just test
+just test-file spec/cli_spec.cr
 ./sequin verify:chain
 ./sequin verify:tx
 ./sequin rewards:score-epoch --date YYYY-MM-DD


### PR DESCRIPTION
## Summary
- add a `just test-file` target to run one Crystal spec file
- document full-suite and single-file test commands in README validation section

## Why
Small changes often only need one focused spec run; this improves local DX and keeps feedback loops fast.

## Testing
- `just test-file spec/cli_spec.cr`
  - 4 examples, 0 failures
